### PR TITLE
gitignore: exclude workspace .cargo-home to avoid PR noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ branches/
 .code/
 
 # trigger: test non-notes change (no [skip ci])
+/.cargo-home/
+/.cargo-cache/


### PR DESCRIPTION
Summary

- Add `.cargo-home/` to the root `.gitignore`.

Rationale

- Our CI and local build helper (`./build-fast.sh`) explicitly set `CARGO_HOME` to `${REPO_ROOT}/.cargo-home`, which creates a workspace-local Cargo cache. Those cache files are not source and should not appear in PRs. Including them causes noisy diffs and can lead to merge conflicts when testing PRs locally.
- The reported issue title mentions `.cache-home`, but the repo actually uses `.cargo-home` (see `build-fast.sh` and workflow env). This change ignores the correct directory.

Scope

- Change is limited to `.gitignore` only. No product/code changes.

Validation

- Searched the repo for `CARGO_HOME` and confirmed `.cargo-home` is the intended path created during builds.
- No Rust code touched, so no build changes required. Behavior is unaffected other than preventing cache files from being tracked.

Closes: #63

---
Auto-generated for issue #63 by a workflow.
Author: @5ocworkshop

Closes #63