### PR TITLE
gitignore: exclude .cargo-home and .cache-home caches from PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ branches/
 .code/
 
 # trigger: test non-notes change (no [skip ci])
+/.cargo-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ actions-runner/
 
 # caches
 .cache/
+/.cache-home/
+/.cargo-home/
 .turbo/
 .parcel-cache/
 .eslintcache


### PR DESCRIPTION
This PR updates the repository `.gitignore` to exclude two local cache directories that occasionally show up in contributor pull requests and disrupt review/merge flows:

- `/.cargo-home/`
- `/.cache-home/`

These are per-user cache directories created by local tooling (e.g., Cargo configured with a custom `CARGO_HOME`, or other developer/environment caches). They should not be versioned and have caused confusion and merge conflicts when PR authors accidentally included them.

Why this change
- Keeps PRs clean from environment-specific caches.
- Prevents accidental commits of large/unrelated cache contents.
- Aligns with existing policy to ignore other cache directories.

Validation
- No runtime or build impact; this is a Git ignore-only change.
- Ran `./build-fast.sh` to ensure the repository still builds successfully.

Closes #63.

---
Auto-generated for issue #63 by a workflow.
Author: @just-every-code

Closes #63