### PR TITLE
[qwen-shortcuts-support] feat(agents/shortcuts): add Qwen‑coder to /plan, /solve, /code

### DIFF
--- a/codex-rs/core/src/agent_tool.rs
+++ b/codex-rs/core/src/agent_tool.rs
@@ -612,6 +612,14 @@ async fn execute_model_with_permissions(
                 cmd.args(&["-m", "gemini-2.5-pro", "-y", "-p", prompt]);
             }
         }
+        "qwen" => {
+            // Qwen coder: follow Gemini CLI UX, but do not pin a model.
+            if read_only {
+                cmd.args(&["-p", prompt]);
+            } else {
+                cmd.args(&["-y", "-p", prompt]);
+            }
+        }
         "codex" | "code" => {
             if read_only {
                 cmd.args(&["-s", "read-only", "-a", "never", "exec", "--skip-git-repo-check", prompt]);
@@ -716,6 +724,11 @@ async fn execute_model_with_permissions(
                 if !read_only { args.push("-y".to_string()); }
                 args.extend(["-p".to_string(), prompt.to_string()]);
             }
+            "qwen" => {
+                // Do not specify a model to allow latest default.
+                if !read_only { args.push("-y".to_string()); }
+                args.extend(["-p".to_string(), prompt.to_string()]);
+            }
             "codex" | "code" => {
                 args.extend(["-s".to_string(), if read_only { "read-only" } else { "workspace-write" }.to_string()]);
                 args.extend(["-a".to_string(), "never".to_string(), "exec".to_string(), "--skip-git-repo-check".to_string(), prompt.to_string()]);
@@ -810,8 +823,8 @@ pub fn create_run_agent_tool() -> OpenAiTool {
     properties.insert(
         "model".to_string(),
         JsonSchema::String {
-            description: Some(
-                "Model: 'claude', 'gemini', or 'code' (or array of models for batch execution)"
+        description: Some(
+                "Model: 'claude', 'gemini', 'qwen', or 'code' (or array of models for batch execution)"
                     .to_string(),
             ),
         },

--- a/codex-rs/core/src/agent_tool.rs
+++ b/codex-rs/core/src/agent_tool.rs
@@ -613,8 +613,22 @@ async fn execute_model_with_permissions(
             }
         }
         "qwen" => {
-            // Qwen coder: follow Gemini CLI UX, but do not pin a model.
-            if read_only {
+            // Qwen coder: follow Gemini CLI UX by default, and do not pin a model
+            // unless the user explicitly sets QWEN_MODEL in the environment.
+            // We intentionally omit default "-m" to track the CLI's latest default model.
+            if let Ok(model_override) = std::env::var("QWEN_MODEL") {
+                if !model_override.trim().is_empty() {
+                    if read_only {
+                        cmd.args(&["-m", &model_override, "-p", prompt]);
+                    } else {
+                        cmd.args(&["-m", &model_override, "-y", "-p", prompt]);
+                    }
+                } else if read_only {
+                    cmd.args(&["-p", prompt]);
+                } else {
+                    cmd.args(&["-y", "-p", prompt]);
+                }
+            } else if read_only {
                 cmd.args(&["-p", prompt]);
             } else {
                 cmd.args(&["-y", "-p", prompt]);
@@ -662,6 +676,20 @@ async fn execute_model_with_permissions(
         }
         if let Some(anthropic_base) = env.get("ANTHROPIC_BASE_URL").cloned() {
             env.entry("CLAUDE_BASE_URL".to_string()).or_insert(anthropic_base);
+        }
+        // Qwen/DashScope convenience: mirror API keys and base URLs both ways so
+        // either variable name works across tools.
+        if let Some(qwen_key) = env.get("QWEN_API_KEY").cloned() {
+            env.entry("DASHSCOPE_API_KEY".to_string()).or_insert(qwen_key);
+        }
+        if let Some(dashscope_key) = env.get("DASHSCOPE_API_KEY").cloned() {
+            env.entry("QWEN_API_KEY".to_string()).or_insert(dashscope_key);
+        }
+        if let Some(qwen_base) = env.get("QWEN_BASE_URL").cloned() {
+            env.entry("DASHSCOPE_BASE_URL".to_string()).or_insert(qwen_base);
+        }
+        if let Some(ds_base) = env.get("DASHSCOPE_BASE_URL").cloned() {
+            env.entry("QWEN_BASE_URL".to_string()).or_insert(ds_base);
         }
         // Reduce startup overhead for Claude CLI: disable auto-updater/telemetry.
         env.entry("DISABLE_AUTOUPDATER".to_string()).or_insert("1".to_string());
@@ -725,7 +753,13 @@ async fn execute_model_with_permissions(
                 args.extend(["-p".to_string(), prompt.to_string()]);
             }
             "qwen" => {
-                // Do not specify a model to allow latest default.
+                // Respect QWEN_MODEL override if set in the effective env; otherwise
+                // omit -m to allow the CLI to pick its latest default.
+                if let Some(m) = env.get("QWEN_MODEL").cloned() {
+                    if !m.trim().is_empty() {
+                        args.extend(["-m".to_string(), m]);
+                    }
+                }
                 if !read_only { args.push("-y".to_string()); }
                 args.extend(["-p".to_string(), prompt.to_string()]);
             }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3941,6 +3941,7 @@ async fn handle_run_agent(sess: &Session, ctx: &ToolCallCtx, arguments: String) 
                     // External CLIs expected to be in PATH
                     "claude" => ("claude".to_string(), false),
                     "gemini" => ("gemini".to_string(), false),
+                    "qwen" => ("qwen".to_string(), false),
                     _ => (m, false),
                 }
             }

--- a/codex-rs/core/src/slash_commands.rs
+++ b/codex-rs/core/src/slash_commands.rs
@@ -19,6 +19,7 @@ fn get_default_models() -> Vec<String> {
     vec![
         "claude".to_string(),
         "gemini".to_string(),
+        "qwen".to_string(),
         "codex".to_string(),
     ]
 }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4197,6 +4197,7 @@ impl ChatWidget<'_> {
         } else {
             to_check.push(("claude".to_string(), "claude".to_string(), false));
             to_check.push(("gemini".to_string(), "gemini".to_string(), false));
+            to_check.push(("qwen".to_string(), "qwen".to_string(), false));
             to_check.push(("code".to_string(), "code".to_string(), true));
         }
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -36,6 +36,29 @@ description = "Google Gemini AI assistant in read-only mode"
 args = []
 
 [[agents]]
+name = "qwen"
+command = "qwen"
+enabled = true
+read-only = false
+description = "Qwen Coder assistant (tracks latest default model)"
+# No default -m: let the CLI choose its current default model
+# To pin a model explicitly, export QWEN_MODEL or add here, e.g.:
+# args = ["-m", "qwen3-coder", "-y"]
+args = ["-y"]
+# Optional environment variables (either name works; mirrored automatically):
+# env = { QWEN_API_KEY = "your-key", DASHSCOPE_API_KEY = "your-key" }
+
+[[agents]]
+name = "qwen-safe"
+command = "qwen"
+enabled = true
+read-only = true
+description = "Qwen Coder assistant in read-only mode"
+# No -y in read-only; omit -m to track latest default. To pin:
+# args = ["-m", "qwen3-coder"]
+args = []
+
+[[agents]]
 name = "codex"
 command = "codex"
 enabled = true


### PR DESCRIPTION
This PR adds first‑class support for Qwen‑coder across the multi‑agent shortcuts and UI:

- Add `qwen` as a default model for `/plan`, `/solve`, and `/code`
- Teach the agent runner to invoke the Qwen CLI with sensible defaults (no model pin)
  - Read‑only: `qwen -p <prompt>`
  - Write mode: `qwen -y -p <prompt>`
- Respect optional `QWEN_MODEL` to pass `-m <model>` when explicitly set
- Show `qwen` availability in the TUI Help → Availability section
- Recognize `qwen` in command‑existence checks when starting agents
- Provide example `qwen` and `qwen-safe` entries in `config.toml.example`
- Minor schema/help text tweak to mention `'qwen'` among supported model names

Rationale
- Issue #141 requests using Qwen‑coder in `/plan` (and other shortcuts). Avoiding a hard‑pinned model lets the CLI track the latest default (e.g., Qwen3‑Coder) while still allowing an explicit override via `QWEN_MODEL`.

Implementation Notes
- Match Gemini’s integration pattern to keep behavior consistent.
- Do not specify a default model id. If `QWEN_MODEL` is set, we pass `-m`.
- Env passthrough (write‑mode path): if either `QWEN_API_KEY` or `DASHSCOPE_API_KEY` is present, mirror it to the other; same for `QWEN_BASE_URL` ↔ `DASHSCOPE_BASE_URL`. This mirrors the existing Claude/Gemini conveniences.

Validation
- Built locally with `./build-fast.sh` (no warnings/errors reported by the compiler output).
- Verified that:
  - `/plan` default model list now includes `qwen` when no agents are configured.
  - TUI Help availability shows `qwen` and performs PATH checks like other CLIs.
  - Agent runner accepts `model: "qwen"` and spawns the CLI with the expected flags in read‑only and write modes.

Scope & Safety
- No changes to CI, workflows, or secrets.
- Changes are limited to agent selection, prompt shortcuts, and example config.
---
Auto-generated for issue #141 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: qwen-shortcuts-support -->
