### PR TITLE
[websearch-type-mismatch] fix(core/web_search): ensure only supported 'web_search' tool id is used; align test harness and remove legacy preview wording

### DIFF
--- a/scripts/test-responses.js
+++ b/scripts/test-responses.js
@@ -16,7 +16,7 @@ Usage examples:
 Flags:
   --auth chatgpt|api-key|auto   Default: auto (prefer ChatGPT if tokens exist)
   --model <slug>                Default: gpt-4o-mini
-  --tests <csv>                 One or more of: base,json-schema,tools-web-search,tools-web-search-preview,store
+  --tests <csv>                 One or more of: base,json-schema,tools-web-search,store
                                 Default: base,json-schema
   --stream true|false           Use streaming SSE (true) or JSON (false). Default: false
   --store true|false            Force store flag; default depends on test case
@@ -120,13 +120,8 @@ function makePayload(kind, model, stream, store, variant) {
   // Primary user message
   input.push({ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Say ok.' }] });
   let tools = undefined;
-  if (variant === 'tools-web-search') {
-    tools = [ { type: 'web_search' } ];
-    if (kind === 'chatgpt') {
-      // Match Codex behavior: convert to preview tool for ChatGPT backend
-      tools = [ { type: 'web_search' } ];
-    }
-  } else if (variant === 'tools-web-search-preview') {
+  if (variant === 'tools-web-search' || variant === 'tools-web-search-preview') {
+    // Use the supported Responses tool id. Kept identical for ChatGPT/API-key.
     tools = [ { type: 'web_search' } ];
   }
   let text = undefined;


### PR DESCRIPTION
Summary

- Root cause: the Responses API rejects the deprecated tool id `web_search_preview` with 400 "Unsupported tool type". Main already uses the supported `web_search` tool id in the Rust core.
- Change: align the JS test harness help/comments and keep a backward‑compatible alias so both `tools-web-search` and the legacy `tools-web-search-preview` map to the supported `web_search` type. No runtime Rust changes were required because the core already emits `web_search`.

Details

- Verified there are no references to `web_search_preview` in the runtime path:
  - `codex-rs/core/src/openai_tools.rs` serializes the native tool as `{ type: "web_search" }`.
  - Tool selection is gated by `tools_web_search_request`; the default TUI overrides enable it.
  - SSE handling recognizes `web_search_call` output items and updates the TUI state accordingly.
- Updated `scripts/test-responses.js` to:
  - Remove legacy preview wording from the `--tests` help line.
  - Accept `tools-web-search-preview` as an alias for `tools-web-search`, both emitting `{ type: 'web_search' }`.

Validation

- Ran `./build-fast.sh` from repo root: build succeeded cleanly with no warnings emitted by the Rust toolchain.
- Searched the repo to confirm no lingering usages of `web_search_preview` remain in runtime code.

User Impact

- Users on current main already avoid the 400 error. The test harness now reflects the supported tool id and keeps compatibility with any existing scripts invoking the legacy preview variant.

Rationale

- Keep changes minimal and focused: no behavioral changes to the Rust core since it already uses the correct tool id; improve clarity and compatibility in the ancillary test script.
---
Auto-generated for issue #149 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: websearch-type-mismatch -->