### PR TITLE
[new-context-reset] fix(tui): make /new start a fresh core session

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -759,23 +759,19 @@ impl App<'_> {
                             }
                         }
                         SlashCommand::New => {
-                            // Clear the current conversation and start fresh
-                            if let AppState::Chat { widget } = &mut self.app_state {
-                                widget.new_conversation(self.enhanced_keys_supported);
-                            } else {
-                        // If we're not in chat state, create a new chat widget
-                        let mut new_widget = ChatWidget::new(
-                            self.config.clone(),
-                            self.app_event_tx.clone(),
-                            None,
-                            Vec::new(),
-                            self.enhanced_keys_supported,
-                            self.terminal_info.clone(),
-                            self.show_order_overlay,
-                        );
-                        new_widget.enable_perf(self.timing_enabled);
-                        self.app_state = AppState::Chat { widget: Box::new(new_widget) };
-                            }
+                            // Start a brand new conversation (core session) with no carried history.
+                            // Replace the chat widget entirely, mirroring SwitchCwd flow but without import.
+                            let mut new_widget = ChatWidget::new(
+                                self.config.clone(),
+                                self.app_event_tx.clone(),
+                                None,
+                                Vec::new(),
+                                self.enhanced_keys_supported,
+                                self.terminal_info.clone(),
+                                self.show_order_overlay,
+                            );
+                            new_widget.enable_perf(self.timing_enabled);
+                            self.app_state = AppState::Chat { widget: Box::new(new_widget) };
                             self.app_event_tx.send(AppEvent::RequestRedraw);
                         }
                         SlashCommand::Init => {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -8039,40 +8039,8 @@ impl ChatWidget<'_> {
 
     
 
-    /// Clear the conversation and start fresh with a new welcome animation
-    pub(crate) fn new_conversation(&mut self, enhanced_keys_supported: bool) {
-        // Clear all history cells
-        self.history_cells.clear();
-        self.cell_order_seq.clear();
-
-        // Reset various state
-        self.active_exec_cell = None;
-        self.clear_token_usage();
-
-        // Add a new animated welcome cell at the top of the next request so
-        // upcoming output appears below it.
-        self.history_push_top_next_req(history_cell::new_animated_welcome());
-        self.reasoning_index.clear();
-        self.stream_order_seq.clear();
-        self.synthetic_system_req = None;
-        self.system_cell_by_id.clear();
-
-        // Reset the bottom pane with a new composer
-        // (This effectively clears the text input)
-        self.bottom_pane = BottomPane::new(BottomPaneParams {
-            app_event_tx: self.app_event_tx.clone(),
-            has_input_focus: true,
-            enhanced_keys_supported,
-            using_chatgpt_auth: self.config.using_chatgpt_auth,
-        });
-        self.access_status_idx = None;
-        self.pending_access_note = None;
-        // Re-apply access indicator for new composer
-        self.apply_access_mode_indicator_from_config();
-
-        // Request redraw for the new animation
-        self.mark_needs_redraw();
-    }
+    // (Removed) Legacy in-place reset method. The /new command now creates a fresh
+    // ChatWidget (new core session) to ensure the agent context is fully reset.
 
     pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
         // Hide the terminal cursor whenever a top‑level overlay is active so the


### PR DESCRIPTION
Summary
- Fixes issue where `/new` did not fully reset context by only clearing the TUI state and keeping the existing core conversation alive.

Root Cause
- The `/new` handler called `ChatWidget::new_conversation()`, which cleared local UI history/composer but did not start a new Codex core session. The existing conversation (and its context) persisted on the core side, so subsequent turns still had prior context.

Changes
- Replace `/new` handling to construct a brand‑new `ChatWidget` (spawns a new core conversation via `ConversationManager::new_conversation`) and swap it into `AppState::Chat`.
- Remove the now‑unused `ChatWidget::new_conversation` method to avoid dead‑code warnings.

Files
- `codex-rs/tui/src/app.rs`: Update `SlashCommand::New` handler to create a new `ChatWidget` and request redraw.
- `codex-rs/tui/src/chatwidget.rs`: Remove legacy `new_conversation` method.

Validation
- Built locally with `./build-fast.sh` (policy-required). Build completed successfully with zero warnings.
- Manual reasoning: starting a new `ChatWidget` triggers a new core session (fresh context). No history is imported, so prior conversation context is not sent to the model. This matches the expected behavior of `/new`.

Notes
- This change is minimal and mirrors existing widget-swap flows (e.g., `SwitchCwd`) without carrying over history.

Closes #157
---
Auto-generated for issue #157 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: new-context-reset -->