### PR TITLE
fix(tui): add intersection checks for input boxes in `AgentEditorView`

### DIFF
--- a/codex-rs/tui/src/bottom_pane/agent_editor_view.rs
+++ b/codex-rs/tui/src/bottom_pane/agent_editor_view.rs
@@ -384,37 +384,46 @@ impl<'a> BottomPaneView<'a> for AgentEditorView {
 
         // Draw input boxes at the same y offsets we reserved above
         let ro_rect = Rect { x: content.x, y: content.y.saturating_add(ro_offset), width: content.width, height: ro_height };
+        let ro_rect = ro_rect.intersection(*buf.area());
         let ro_block = Block::default()
             .borders(Borders::ALL)
             .title(Line::from(" Read-only Params "))
             .border_style(if self.field == 1 { Style::default().fg(crate::colors::primary()).add_modifier(Modifier::BOLD) } else { Style::default().fg(crate::colors::border()) });
-        let ro_inner_rect = ro_block.inner(ro_rect);
-        let ro_inner = ro_inner_rect.inner(Margin::new(1, 0));
-        ro_block.render(ro_rect, buf);
-        Self::clear_rect(buf, ro_inner_rect);
-        self.params_ro.render(ro_inner, buf, self.field == 1);
+        if ro_rect.width > 0 && ro_rect.height > 0 {
+            let ro_inner_rect = ro_block.inner(ro_rect);
+            let ro_inner = ro_inner_rect.inner(Margin::new(1, 0));
+            ro_block.render(ro_rect, buf);
+            Self::clear_rect(buf, ro_inner_rect);
+            self.params_ro.render(ro_inner, buf, self.field == 1);
+        }
 
         // WR params box (3 rows)
         let wr_rect = Rect { x: content.x, y: content.y.saturating_add(wr_offset), width: content.width, height: wr_height };
+        let wr_rect = wr_rect.intersection(*buf.area());
         let wr_block = Block::default()
             .borders(Borders::ALL)
             .title(Line::from(" Write Params "))
             .border_style(if self.field == 2 { Style::default().fg(crate::colors::primary()).add_modifier(Modifier::BOLD) } else { Style::default().fg(crate::colors::border()) });
-        let wr_inner_rect = wr_block.inner(wr_rect);
-        let wr_inner = wr_inner_rect.inner(Margin::new(1, 0));
-        wr_block.render(wr_rect, buf);
-        Self::clear_rect(buf, wr_inner_rect);
-        self.params_wr.render(wr_inner, buf, self.field == 2);
+        if wr_rect.width > 0 && wr_rect.height > 0 {
+            let wr_inner_rect = wr_block.inner(wr_rect);
+            let wr_inner = wr_inner_rect.inner(Margin::new(1, 0));
+            wr_block.render(wr_rect, buf);
+            Self::clear_rect(buf, wr_inner_rect);
+            self.params_wr.render(wr_inner, buf, self.field == 2);
+        }
 
         // Instructions (multi-line; height consistent with reserved space above)
         let instr_rect = Rect { x: content.x, y: content.y.saturating_add(instr_offset), width: content.width, height: instr_height };
+        let instr_rect = instr_rect.intersection(*buf.area());
         let instr_block = Block::default().borders(Borders::ALL).border_style(if self.field == 3 { Style::default().fg(crate::colors::primary()).add_modifier(Modifier::BOLD) } else { Style::default().fg(crate::colors::border()) });
         let instr_block = instr_block.title(Line::from(" Instructions "));
-        let instr_inner_rect = instr_block.inner(instr_rect);
-        let instr_inner = instr_inner_rect.inner(Margin::new(1, 0));
-        instr_block.render(instr_rect, buf);
-        Self::clear_rect(buf, instr_inner_rect);
-        self.instr.render(instr_inner, buf, self.field == 3);
+        if instr_rect.width > 0 && instr_rect.height > 0 {
+            let instr_inner_rect = instr_block.inner(instr_rect);
+            let instr_inner = instr_inner_rect.inner(Margin::new(1, 0));
+            instr_block.render(instr_rect, buf);
+            Self::clear_rect(buf, instr_inner_rect);
+            self.instr.render(instr_inner, buf, self.field == 3);
+        }
     }
 }
 


### PR DESCRIPTION
Panic when select items in `/agents` widget.
<img width="508" height="295" alt="image" src="https://github.com/user-attachments/assets/b3161640-b0eb-4a6f-a77e-150687d48717" />


```console

The application panicked (crashed).
Message:  index outside of buffer: the area is Rect { x: 0, y: 0, width: 128, height: 19 } but index is (4, 21)
Location: /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/buffer/buffer.rs:253

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 10 frames hidden ⋮                              
  11: ratatui::buffer::buffer::Buffer::index_of::{{closure}}::h04e82208d40decd1
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/buffer/buffer.rs:253
       251 │     pub fn index_of(&self, x: u16, y: u16) -> usize {
       252 │         self.index_of_opt(Position { x, y }).unwrap_or_else(|| {
       253 >             panic!(
       254 │                 "index outside of buffer: the area is {area:?} but index is ({x}, {y})",
       255 │                 area = self.area,
  12: core::option::Option<T>::unwrap_or_else::hf7946a691124f438
      at /home/xus/.rustup/toolchains/1.89.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:1050
      1048 │         match self {
      1049 │             Some(x) => x,
      1050 >             None => f(),
      1051 │         }
      1052 │     }
  13: ratatui::buffer::buffer::Buffer::index_of::hb0494437417d7920
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/buffer/buffer.rs:252
       250 │     #[must_use]
       251 │     pub fn index_of(&self, x: u16, y: u16) -> usize {
       252 >         self.index_of_opt(Position { x, y }).unwrap_or_else(|| {
       253 │             panic!(
       254 │                 "index outside of buffer: the area is {area:?} but index is ({x}, {y})",
  14: <ratatui::buffer::buffer::Buffer as core::ops::index::IndexMut<P>>::index_mut::h1b7f831427ee7ddf
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/buffer/buffer.rs:568
       566 │     fn index_mut(&mut self, position: P) -> &mut Self::Output {
       567 │         let position = position.into();
       568 >         let index = self.index_of(position.x, position.y);
       569 │         &mut self.content[index]
       570 │     }
  15: codex_tui::bottom_pane::agent_editor_view::AgentEditorView::clear_rect::h4bc18b16234007ac
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/bottom_pane/agent_editor_view.rs:50
        48 │         for y in rect.y..rect.y.saturating_add(rect.height) {
        49 │             for x in rect.x..rect.x.saturating_add(rect.width) {
        50 >                 let cell = &mut buf[(x, y)];
        51 │                 cell.set_symbol(" ");
        52 │                 cell.set_style(style);
  16: <codex_tui::bottom_pane::agent_editor_view::AgentEditorView as codex_tui::bottom_pane::bottom_pane_view::BottomPaneView>::render::h72b0aa601634e773
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/bottom_pane/agent_editor_view.rs:424
       422 │         let wr_inner = wr_inner_rect.inner(Margin::new(1, 0));
       423 │         wr_block.render(wr_rect, buf);
       424 >         Self::clear_rect(buf, wr_inner_rect);
       425 │         self.params_wr.render(wr_inner, buf, self.field == 2);
       426 │ 
  17: <&codex_tui::chatwidget::ChatWidget as ratatui::widgets::WidgetRef>::render_ref::hc370c9eda3ec3cb9
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/chatwidget.rs:11446
     11444 │         // Render the bottom pane directly without a border for now
     11445 │         // The composer has its own layout with hints at the bottom
     11446 >         (&self.bottom_pane).render(bottom_pane_area, buf);
     11447 │ 
     11448 │         // Welcome animation is kept as a normal cell in history; no overlay.
  18: ratatui::terminal::frame::Frame::render_widget_ref::h6de4a9ccfcb61f8f
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/terminal/frame.rs:122
       120 │     #[instability::unstable(feature = "widget-ref")]
       121 │     pub fn render_widget_ref<W: WidgetRef>(&mut self, widget: W, area: Rect) {
       122 >         widget.render_ref(area, self.buffer);
       123 │     }
       124 │ 
  19: codex_tui::app::App::draw_next_frame::{{closure}}::hd7e3f4070251d284
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/app.rs:1472
      1470 │                         frame.set_cursor_position((x, y));
      1471 │                     }
      1472 >                     frame.render_widget_ref(&**widget, frame.area())
      1473 │                 }
      1474 │                 AppState::Onboarding { screen } => frame.render_widget_ref(&*screen, frame.area()),
  20: ratatui::terminal::terminal::Terminal<B>::draw::{{closure}}::h96db98e27d087087
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/terminal/terminal.rs:309
       307 │     {
       308 │         self.try_draw(|frame| {
       309 >             render_callback(frame);
       310 │             io::Result::Ok(())
       311 │         })
  21: ratatui::terminal::terminal::Terminal<B>::try_draw::h93bb541c9f31f4ba
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/terminal/terminal.rs:390
       388 │         let mut frame = self.get_frame();
       389 │ 
       390 >         render_callback(&mut frame).map_err(Into::into)?;
       391 │ 
       392 │         // We can't change the cursor position right away because we have to flush the frame to
  22: ratatui::terminal::terminal::Terminal<B>::draw::heea96d9d6e7d7dcd
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ratatui-0.29.0/src/terminal/terminal.rs:308
       306 │         F: FnOnce(&mut Frame),
       307 │     {
       308 >         self.try_draw(|frame| {
       309 │             render_callback(frame);
       310 │             io::Result::Ok(())
  23: codex_tui::app::App::draw_next_frame::h942ff635feb3c7fc
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/app.rs:1466
      1464 │         self.last_frame_size = Some(screen_size);
      1465 │ 
      1466 >         terminal.draw(|frame| {
      1467 │             match &mut self.app_state {
      1468 │                 AppState::Chat { widget } => {
  24: codex_tui::app::App::run::{{closure}}::h955e7ad2d0190f93
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/app.rs:444
       442 │                     if self.timing_enabled { self.timing.on_redraw_begin(); }
       443 │                     let t0 = Instant::now();
       444 >                     std::io::stdout().sync_update(|_| self.draw_next_frame(terminal))??;
       445 │                     if self.timing_enabled { self.timing.on_redraw_end(t0); }
       446 │                 }
  25: <W as crossterm::command::SynchronizedUpdate>::sync_update::h9011f25bc6fe4b27
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossterm-0.28.1/src/command.rs:247
       245 │     fn sync_update<T>(&mut self, operations: impl FnOnce(&mut Self) -> T) -> io::Result<T> {
       246 │         self.queue(BeginSynchronizedUpdate)?;
       247 >         let result = operations(self);
       248 │         self.execute(EndSynchronizedUpdate)?;
       249 │         Ok(result)
  26: codex_tui::app::App::run::h27d4ee80e3cb8880
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/app.rs:444
       442 │                     if self.timing_enabled { self.timing.on_redraw_begin(); }
       443 │                     let t0 = Instant::now();
       444 >                     std::io::stdout().sync_update(|_| self.draw_next_frame(terminal))??;
       445 │                     if self.timing_enabled { self.timing.on_redraw_end(t0); }
       446 │                 }
  27: codex_tui::run_ratatui_app::h7401bdbd9cd0d0ed
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/lib.rs:386
       384 │     );
       385 │ 
       386 >     let app_result = app.run(&mut terminal);
       387 │     let usage = app.token_usage();
       388 │ 
  28: codex_tui::run_main::{{closure}}::h6471b3c7e79c405a
      at /home/xus/code/github/just-every/code/codex-rs/tui/src/lib.rs:282
       280 │     }
       281 │ 
       282 >     run_ratatui_app(cli, config, should_show_trust_screen)
       283 │         .map_err(|err| std::io::Error::other(err.to_string()))
       284 │ }
  29: code::cli_main::{{closure}}::h8b7601bc3daa70c9
      at /home/xus/code/github/just-every/code/codex-rs/cli/src/main.rs:218
       216 │                 root_config_overrides.clone(),
       217 │             );
       218 >             let usage = codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
       219 │             if !usage.is_zero() {
       220 │                 println!("{}", codex_core::protocol::FinalOutput::from(usage));
  30: code::main::{{closure}}::{{closure}}::h61ebbe4ddc66fda7
      at /home/xus/code/github/just-every/code/codex-rs/cli/src/main.rs:200
       198 │ fn main() -> anyhow::Result<()> {
       199 │     arg0_dispatch_or_else(|codex_linux_sandbox_exe| async move {
       200 >         cli_main(codex_linux_sandbox_exe).await?;
       201 │         Ok(())
       202 │     })
  31: codex_arg0::arg0_dispatch_or_else::{{closure}}::he701e5dfd216e1d2
      at /home/xus/code/github/just-every/code/codex-rs/arg0/src/lib.rs:103
       101 │         };
       102 │ 
       103 >         main_fn(codex_linux_sandbox_exe).await
       104 │     })
       105 │ }
  32: tokio::runtime::park::CachedParkThread::block_on::{{closure}}::h37186c5b3f618f94
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285
       283 │ 
       284 │         loop {
       285 >             if let Ready(v) = crate::task::coop::budget(|| f.as_mut().poll(&mut cx)) {
       286 │                 return Ok(v);
       287 │             }
  33: tokio::task::coop::with_budget::h56d3d4fef7ba6cba
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:167
       165 │     // The function is called regardless even if the budget is not successfully
       166 │     // set due to the thread-local being destroyed.
       167 >     f()
       168 │ }
       169 │ 
  34: tokio::task::coop::budget::h8c44b2ecf4b9e92c
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:133
       131 │ #[inline(always)]
       132 │ pub(crate) fn budget<R>(f: impl FnOnce() -> R) -> R {
       133 >     with_budget(Budget::initial(), f)
       134 │ }
       135 │ 
  35: tokio::runtime::park::CachedParkThread::block_on::h4bb8b418ed5793dd
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285
       283 │ 
       284 │         loop {
       285 >             if let Ready(v) = crate::task::coop::budget(|| f.as_mut().poll(&mut cx)) {
       286 │                 return Ok(v);
       287 │             }
  36: tokio::runtime::context::blocking::BlockingRegionGuard::block_on::h667d7c9d8e788e6d
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/blocking.rs:66
        64 │ 
        65 │         let mut park = CachedParkThread::new();
        66 >         park.block_on(f)
        67 │     }
        68 │ 
  37: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}::hc3106e6d53c33e2f
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/mod.rs:87
        85 │     {
        86 │         crate::runtime::context::enter_runtime(handle, true, |blocking| {
        87 >             blocking.block_on(future).expect("failed to park thread")
        88 │         })
        89 │     }
  38: tokio::runtime::context::runtime::enter_runtime::h17036a24d3c1116c
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/runtime.rs:65
        63 │ 
        64 │     if let Some(mut guard) = maybe_guard {
        65 >         return f(&mut guard.blocking);
        66 │     }
        67 │ 
  39: tokio::runtime::runtime::Runtime::block_on_inner::h47c93c82e8721e25
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:358
       356 │             Scheduler::CurrentThread(exec) => exec.block_on(&self.handle.inner, future),
       357 │             #[cfg(feature = "rt-multi-thread")]
       358 >             Scheduler::MultiThread(exec) => exec.block_on(&self.handle.inner, future),
       359 │         }
       360 │     }
  40: tokio::runtime::runtime::Runtime::block_on::h4e63b1cd50e32af2
      at /home/xus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:328
       326 │         let fut_size = mem::size_of::<F>();
       327 │         if fut_size > BOX_FUTURE_THRESHOLD {
       328 >             self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
       329 │         } else {
       330 │             self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))
  41: codex_arg0::arg0_dispatch_or_else::h5721737d908eb10d
      at /home/xus/code/github/just-every/code/codex-rs/arg0/src/lib.rs:96
        94 │     // async entry-point.
        95 │     let runtime = tokio::runtime::Runtime::new()?;
        96 >     runtime.block_on(async move {
        97 │         let codex_linux_sandbox_exe: Option<PathBuf> = if cfg!(target_os = "linux") {
        98 │             std::env::current_exe().ok()
  42: core::ops::function::FnOnce::call_once::h7fd97438ce5e81c1
      at /home/xus/.rustup/toolchains/1.89.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250
       248 │     /// Performs the call operation.
       249 │     #[unstable(feature = "fn_traits", issue = "29625")]
       250 >     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
       251 │ }
       252 │ 
  43: std::sys::backtrace::__rust_begin_short_backtrace::hdfacca8caae708f1
      at /home/xus/.rustup/toolchains/1.89.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152
       150 │     F: FnOnce() -> T,
       151 │ {
       152 >     let result = f();
       153 │ 
       154 │     // prevent this frame from being tail-call optimised away
                                ⋮ 13 frames hidden ⋮                              

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
```