### PR TITLE
[config-dir-clarify] docs(readme): fix config dir to ~/.code; clarify ~/.codex precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   - 🧠 **Reasoning Control** - /reasoning for dynamic effort adjustment
   - 🔌 **MCP support** – Extend with filesystem, DBs, APIs, or your own tools.
   - 🔒 **Safety modes** – Read-only, approvals, and workspace sandboxing.
-  - 🔁 **Backwards compatible** – Supports `~/.codex/*` or default `~/.coder/*`
+  - 🔁 **Backwards compatible** – Supports `~/.codex/*` (if present) or defaults to `~/.code/*`
 
 &ensp;
 | <img src="docs/screenshots/simple.png" alt="Simple interface" width="100%"><br>Simple interface | <img src="docs/screenshots/diff.png" alt="Unified diff viewer" width="100%"><br>Unified diffs |
@@ -51,7 +51,7 @@ Note: If another tool already provides a `code` command (e.g. VS Code), our CLI 
 **Authenticate** (one of the following):
 - **Sign in with ChatGPT** (Plus/Pro/Team; uses models available to your plan)
   - Run `code` and pick "Sign in with ChatGPT"
-  - Stores creds locally at `~/.coder/auth.json` (also reads legacy `~/.codex/auth.json`)
+  - Stores creds locally at `~/.code/auth.json` (also reads legacy `~/.codex/auth.json`)
 - **API key** (usage-based)
   - Set `export OPENAI_API_KEY=xyz` and run `code`
 


### PR DESCRIPTION
Fixes #181

This PR corrects misleading configuration directory references in the README and clarifies precedence between legacy and fork paths.

What changed
- Replace `~/.coder` with `~/.code` in two spots:
  - Backwards-compat note now reads: "Supports `~/.codex/*` (if present) or defaults to `~/.code/*`".
  - Auth storage path now references `~/.code/auth.json` (still reads legacy `~/.codex/auth.json`).

Why
- The code resolves the config home via `CODE_HOME`/`CODEX_HOME`, then falls back to:
  - `~/.codex` if it exists (backward compatibility), otherwise
  - `~/.code` (fork default).
- README incorrectly mentioned `~/.coder`, which is unrelated to config resolution.

References
- Implementation: `codex-rs/core/src/config.rs` (`find_codex_home`) uses `~/.codex` if present, else `~/.code`.

Validation
- Ran `./build-fast.sh` from repo root; build completed successfully with no warnings or errors.

Impact
- Documentation now matches actual behavior; users won’t be misled about where configuration and auth are stored.
---
Auto-generated for issue #181 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: config-dir-clarify -->