### PR TITLE
[pulldown-cmark-dep] fix(tui): add missing pulldown-cmark dep to codex-tui to restore build

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1207,6 +1207,7 @@ dependencies = [
  "once_cell",
  "path-clean",
  "pretty_assertions",
+ "pulldown-cmark 0.11.3",
  "rand 0.9.2",
  "ratatui",
  "ratatui-image",
@@ -4127,6 +4128,19 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+dependencies = [
+ "bitflags 2.9.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
@@ -6152,7 +6166,7 @@ dependencies = [
  "ansi-to-tui",
  "itertools 0.14.0",
  "pretty_assertions",
- "pulldown-cmark",
+ "pulldown-cmark 0.13.0",
  "ratatui",
  "rstest",
  "syntect",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -89,6 +89,7 @@ futures = "0.3"
 syntect = { version = "5", features = ["yaml-load", "plist-load", "parsing", "default-syntaxes"] }
 which = "6"
 urlencoding = "2.1"
+pulldown-cmark = "0.11"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
Issue: #186

Summary

- The `codex-tui` crate directly uses `pulldown_cmark` in `src/markdown_render.rs` and `src/bin/md-events.rs`, but the dependency was not declared in `codex-rs/tui/Cargo.toml`.
- This caused `cargo build --release` (and our `./build-fast.sh`) to fail with: “use of unresolved module or unlinked crate `pulldown_cmark`”.

Changes

- Add `pulldown-cmark = "0.11"` under `[dependencies]` in `codex-rs/tui/Cargo.toml`.

Why this is safe/minimal

- No code changes; only the missing dependency declaration was added.
- `pulldown_cmark` is already referenced by the TUI sources (`markdown_render.rs`, `md-events.rs`), so this aligns Cargo metadata with existing code.

Validation

- Ran `./build-fast.sh` from repo root. Build completed successfully with no compiler warnings.
- Confirmed the `codex-tui` bin `md-events` compiles as part of the workspace build.

Artifacts

- Build command: `./build-fast.sh` (default dev-fast profile).
- Result: ✅ success.

Notes

- No changes to CI/workflows or unrelated areas.
---
Auto-generated for issue #186 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: pulldown-cmark-dep -->