### PR TITLE
[backspace-help-conflict] fix(tui/help): rebind Help from Ctrl+H to F1 to avoid backspace conflict

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1642,7 +1642,7 @@ impl WidgetRef for ChatComposer {
                         }
                         // Always show help at the end of the command hints
                         if !spans.is_empty() { spans.push(Span::from("  •  ").style(label_style)); }
-                        spans.push(Span::from("Ctrl+H").style(key_hint_style));
+                        spans.push(Span::from("F1").style(key_hint_style));
                         spans.push(Span::from(" help").style(label_style));
                     }
                     spans

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -5297,7 +5297,7 @@ impl ChatWidget<'_> {
         ));
 
         // Global
-        lines.push(kv("Ctrl+H", "Help overlay"));
+        lines.push(kv("F1", "Help overlay"));
         lines.push(kv("Ctrl+R", "Toggle reasoning"));
         lines.push(kv("Ctrl+T", "Toggle screen"));
         lines.push(kv("Ctrl+D", "Diff viewer"));

--- a/codex-rs/tui/src/chatwidget/help_handlers.rs
+++ b/codex-rs/tui/src/chatwidget/help_handlers.rs
@@ -5,9 +5,9 @@ use crossterm::event::{KeyCode, KeyEvent};
 
 // Returns true if the key was handled by the help overlay (or toggled it closed).
 pub(super) fn handle_help_key(chat: &mut ChatWidget<'_>, key_event: KeyEvent) -> bool {
-    // If no help overlay, only intercept Ctrl+H to open it.
+    // If no help overlay, intercept F1 to open it.
     if chat.help.overlay.is_none() {
-        if let KeyEvent { code: KeyCode::Char('h'), modifiers: crossterm::event::KeyModifiers::CONTROL, .. } = key_event {
+        if let KeyEvent { code: KeyCode::F(1), .. } = key_event {
             chat.toggle_help_popup();
             return true;
         }
@@ -56,8 +56,8 @@ pub(super) fn handle_help_key(chat: &mut ChatWidget<'_>, key_event: KeyEvent) ->
             chat.request_redraw();
             true
         }
-        KeyCode::Esc | KeyCode::Char('h') => {
-            // Close on Esc or Ctrl+H
+        KeyCode::Esc | KeyCode::F(1) | KeyCode::Char('h') => {
+            // Close on Esc, F1, or 'h'
             chat.help.overlay = None;
             chat.request_redraw();
             true


### PR DESCRIPTION
Issue: #188

Problem
- On some terminals (notably iTerm2 on macOS), the Backspace key sends Ctrl+H ("^H").
- The TUI globally bound Ctrl+H to open the Help overlay, so pressing Backspace while composing text opened Help instead of deleting the previous character.

What changed
- Rebound the Help overlay shortcut from Ctrl+H to F1 to eliminate the conflict.
- Updated footer/composer hints and the Help panel to show "F1" for Help.
- When the Help overlay is open, it now closes on Esc or F1 (toggling behavior), preserving Esc as a universal close.
- Composer behavior remains unchanged: Ctrl+H continues to function as Backspace within the input field.

Files
- codex-rs/tui/src/chatwidget/help_handlers.rs: open/close binding updated to F1; comment adjusted.
- codex-rs/tui/src/chatwidget.rs: Help panel shortcut text changed to "F1".
- codex-rs/tui/src/bottom_pane/chat_composer.rs: footer hint changed from "Ctrl+H help" to "F1 help".

Rationale
- Avoids hijacking Backspace on terminals that emit ^H.
- Keeps a discoverable and standard Help key (F1) without interfering with text entry.

Validation
- Built locally with `./build-fast.sh` (no warnings/errors). 
- Manually reasoned through key routing: with the global Ctrl+H binding removed, the composer’s existing Ctrl+H-as-backspace handling takes effect.
---
Auto-generated for issue #188 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: backspace-help-conflict -->