### PR TITLE
feat(approval-indicator): pause spinner while awaiting confirmation

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1891,6 +1891,11 @@ impl App<'_> {
                     self.terminal_title_override = title;
                     self.apply_terminal_title();
                 }
+                AppEvent::ApprovalRequestResolved => {
+                    if let AppState::Chat { widget } = &mut self.app_state {
+                        widget.approval_request_resolved();
+                    }
+                }
                 AppEvent::UpdateMcpServer { name, enable } => {
                     if let AppState::Chat { widget } = &mut self.app_state {
                         widget.toggle_mcp_server(&name, enable);

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -85,6 +85,9 @@ pub(crate) enum AppEvent {
     /// Update the terminal title override. `None` restores the default title.
     SetTerminalTitle { title: Option<String> },
 
+    /// Notification that a pending approval has been resolved by the user.
+    ApprovalRequestResolved,
+
     /// Schedule a one-shot animation frame roughly after the given duration.
     /// Multiple requests are coalesced by the central frame scheduler.
     ScheduleFrameIn(Duration),

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -249,6 +249,8 @@ impl UserApprovalWidget<'_> {
             let approved = matches!(decision, ReviewDecision::Approved | ReviewDecision::ApprovedForSession);
             self.app_event_tx
                 .send(AppEvent::TerminalApprovalDecision { id: *id, approved });
+            self.app_event_tx
+                .send(AppEvent::ApprovalRequestResolved);
             self.done = true;
             return;
         }
@@ -312,6 +314,8 @@ impl UserApprovalWidget<'_> {
         };
 
         self.app_event_tx.send(AppEvent::CodexOp(op));
+        self.app_event_tx
+            .send(AppEvent::ApprovalRequestResolved);
         self.done = true;
     }
 


### PR DESCRIPTION
This pull request introduces the following changes:
- Pauses the task spinner within the text user interface (TUI) during approval events, ensuring smooth and accurate visual updates.
- Tracks pending approval requests and enhances terminal title feedback to reflect current approval status dynamically.

This allows a user to see the current status of a session at a glance just from the window/tab title.  Currently the spinner makes it appear like the session is running, when really its paused for a confirmation.