### PR TITLE
feat(tui/shortcuts): config-driven key chords + UI labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ Icon?
 # Unwanted package managers
 .yarn/
 yarn.lock
+package-lock.json
 
 # release
 package.json-e

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -580,3 +580,43 @@ Options that are specific to the TUI.
 [tui]
 # More to come here
 ```
+
+### Shortcuts
+
+You can remap core TUI shortcuts via `[tui.shortcuts]`. Each mapping accepts a key chord
+string with the following format options:
+
+- Modifiers: `ctrl`, `alt` (alias: `meta`), `shift`
+- Separators: `+` or `-` (both work): `ctrl+g`, `ctrl-g`, `ctrl-alt-x`
+- Keys: single characters (`a`..`z`), `enter`, `esc`, `tab`, `backtab` (aka `shift+tab`),
+  `insert`, `space`, arrows (`left`, `right`, `up`, `down`), paging (`pageup`, `pagedown`),
+  `home`, `end`, and function keys (`f1`..`f24`).
+
+Example remaps:
+
+```toml
+[tui.shortcuts]
+help = "ctrl-g"
+toggle_browser_hud = "f6"
+toggle_agents_hud = "f7"
+transcript_page_up = "pageup"
+transcript_page_down = "pagedown"
+transcript_to_top = "home"
+transcript_to_bottom = "end"
+composer_cycle_access_mode = "backtab"    # shift+tab
+composer_file_search = "tab"
+composer_send = "enter"
+composer_insert_newline = "shift+enter"
+composer_history_up = "shift+up"
+composer_history_down = "shift+down"
+app_exit_if_empty = "ctrl-d"
+app_toggle_reasoning = "ctrl-r"
+app_toggle_screen = "ctrl-t"
+app_toggle_diffs = "ctrl-d"
+```
+
+Notes:
+
+- The TUI renders the configured labels (e.g., shows `Ctrl+G` for Help if `help = "ctrl-g"`).
+- Advanced editing shortcuts inside the composer (e.g., `Ctrl+W/H/D` text edits) are not yet
+  remappable; only global toggles and footer hints are driven by config today.

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -826,18 +826,7 @@ impl App<'_> {
                                 }
                             }
                         }
-                        KeyEvent {
-                            code: KeyCode::Char('r'),
-                            modifiers: crossterm::event::KeyModifiers::CONTROL,
-                            kind: KeyEventKind::Press,
-                            ..
-                        }
-                        | KeyEvent {
-                            code: KeyCode::Char('r'),
-                            modifiers: crossterm::event::KeyModifiers::CONTROL,
-                            kind: KeyEventKind::Repeat,
-                            ..
-                        } => {
+                        _ if crate::keys::matches_event(&key_event, &self.config.tui.shortcuts.app_toggle_reasoning) => {
                             // Toggle reasoning/thinking visibility (Ctrl+R)
                             match &mut self.app_state {
                                 AppState::Chat { widget } => {
@@ -846,24 +835,14 @@ impl App<'_> {
                                 AppState::Onboarding { .. } => {}
                             }
                         }
-                        KeyEvent {
-                            code: KeyCode::Char('t'),
-                            modifiers: crossterm::event::KeyModifiers::CONTROL,
-                            kind: KeyEventKind::Press | KeyEventKind::Repeat,
-                            ..
-                        } => {
+                        _ if crate::keys::matches_event(&key_event, &self.config.tui.shortcuts.app_toggle_screen) => {
                             let _ = self.toggle_screen_mode(terminal);
                             // Propagate mode to widget so it can adapt layout
                             if let AppState::Chat { widget } = &mut self.app_state {
                                 widget.standard_terminal_mode = !self.alt_screen_active;
                             }
                         }
-                        KeyEvent {
-                            code: KeyCode::Char('d'),
-                            modifiers: crossterm::event::KeyModifiers::CONTROL,
-                            kind: KeyEventKind::Press,
-                            ..
-                        } => {
+                        _ if crate::keys::matches_event(&key_event, &self.config.tui.shortcuts.app_toggle_diffs) => {
                             // Toggle diffs overlay
                             if let AppState::Chat { widget } = &mut self.app_state {
                                 widget.toggle_diffs_popup();

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -122,6 +122,10 @@ pub(crate) struct ChatComposer {
     show_reasoning_hint: bool,
     show_diffs_hint: bool,
     reasoning_shown: bool,
+    // Config-driven labels for footer hints
+    help_hint_label: String,
+    reasoning_hint_label: String,
+    diffs_hint_label: String,
     // Sticky flag: after a chat ScrollUp, make the very next Down trigger
     // chat ScrollDown instead of moving within the textarea, unless another
     // key is pressed in between.
@@ -143,6 +147,9 @@ impl ChatComposer {
         app_event_tx: AppEventSender,
         enhanced_keys_supported: bool,
         using_chatgpt_auth: bool,
+        help_hint_label: String,
+        reasoning_hint_label: String,
+        diffs_hint_label: String,
     ) -> Self {
         let use_shift_enter_hint = enhanced_keys_supported;
 
@@ -174,6 +181,9 @@ impl ChatComposer {
             show_reasoning_hint: false,
             show_diffs_hint: false,
             reasoning_shown: false,
+            help_hint_label,
+            reasoning_hint_label,
+            diffs_hint_label,
             next_down_scrolls_history: false,
             paste_burst: PasteBurst::default(),
         }
@@ -1648,23 +1658,26 @@ impl WidgetRef for ChatComposer {
                 }
 
                 // Helper to build hint spans based on inclusion flags
+                let help_label = self.help_hint_label.clone();
+                let reason_label = self.reasoning_hint_label.clone();
+                let diffs_label = self.diffs_hint_label.clone();
                 let build_hints = |include_reasoning: bool, include_diff: bool| -> Vec<Span> {
                     let mut spans: Vec<Span> = Vec::new();
                     if !self.ctrl_c_quit_hint {
                         if self.show_reasoning_hint && include_reasoning {
                             if !spans.is_empty() { spans.push(Span::from("  •  ").style(label_style)); }
-                            spans.push(Span::from("Ctrl+R").style(key_hint_style));
+                            spans.push(Span::from(reason_label.clone()).style(key_hint_style));
                             let label = if self.reasoning_shown { " hide reasoning" } else { " show reasoning" };
                             spans.push(Span::from(label).style(label_style));
                         }
                         if self.show_diffs_hint && include_diff {
                             if !spans.is_empty() { spans.push(Span::from("  •  ").style(label_style)); }
-                            spans.push(Span::from("Ctrl+D").style(key_hint_style));
+                            spans.push(Span::from(diffs_label.clone()).style(key_hint_style));
                             spans.push(Span::from(" diff viewer").style(label_style));
                         }
                         // Always show help at the end of the command hints
                         if !spans.is_empty() { spans.push(Span::from("  •  ").style(label_style)); }
-                        spans.push(Span::from("Ctrl+H").style(key_hint_style));
+                        spans.push(Span::from(help_label.clone()).style(key_hint_style));
                         spans.push(Span::from(" help").style(label_style));
                     }
                     spans

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -91,6 +91,9 @@ pub(crate) struct BottomPaneParams {
     pub(crate) has_input_focus: bool,
     pub(crate) enhanced_keys_supported: bool,
     pub(crate) using_chatgpt_auth: bool,
+    pub(crate) help_hint_label: String,
+    pub(crate) reasoning_hint_label: String,
+    pub(crate) diffs_hint_label: String,
 }
 
 impl BottomPane<'_> {
@@ -104,6 +107,9 @@ impl BottomPane<'_> {
                 params.app_event_tx.clone(),
                 enhanced_keys_supported,
                 params.using_chatgpt_auth,
+                params.help_hint_label,
+                params.reasoning_hint_label,
+                params.diffs_hint_label,
             ),
             active_view: None,
             app_event_tx: params.app_event_tx,

--- a/codex-rs/tui/src/keys.rs
+++ b/codex-rs/tui/src/keys.rs
@@ -1,0 +1,63 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use codex_core::config_types::{KeyChord, KeyCodeName};
+
+pub fn matches_event(ev: &KeyEvent, chord: &KeyChord) -> bool {
+    let ctrl = ev.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = ev.modifiers.contains(KeyModifiers::ALT);
+    let shift = ev.modifiers.contains(KeyModifiers::SHIFT);
+    if ctrl != chord.ctrl || alt != chord.alt || shift != chord.shift {
+        return false;
+    }
+    match (&ev.code, &chord.code) {
+        (KeyCode::Char(c1), KeyCodeName::Char(c2)) => c1.to_ascii_lowercase() == *c2,
+        (KeyCode::F(n1), KeyCodeName::F(n2)) => *n1 == *n2,
+        (KeyCode::Enter, KeyCodeName::Enter) => true,
+        (KeyCode::Esc, KeyCodeName::Esc) => true,
+        (KeyCode::Tab, KeyCodeName::Tab) => true,
+        (KeyCode::BackTab, KeyCodeName::BackTab) => true,
+        (KeyCode::Insert, KeyCodeName::Insert) => true,
+        (KeyCode::Char(' '), KeyCodeName::Space) => true,
+        (KeyCode::Left, KeyCodeName::Left) => true,
+        (KeyCode::Right, KeyCodeName::Right) => true,
+        (KeyCode::Up, KeyCodeName::Up) => true,
+        (KeyCode::Down, KeyCodeName::Down) => true,
+        (KeyCode::PageUp, KeyCodeName::PageUp) => true,
+        (KeyCode::PageDown, KeyCodeName::PageDown) => true,
+        (KeyCode::Home, KeyCodeName::Home) => true,
+        (KeyCode::End, KeyCodeName::End) => true,
+        _ => false,
+    }
+}
+
+pub fn label_for_chord(ch: &KeyChord) -> String {
+    let mut parts = Vec::new();
+    if ch.ctrl { parts.push("Ctrl".to_string()); }
+    if ch.alt { parts.push("Alt".to_string()); }
+    if ch.shift { parts.push("Shift".to_string()); }
+    let code = match ch.code {
+        KeyCodeName::Char(c) => c.to_ascii_uppercase().to_string(),
+        KeyCodeName::F(n) => format!("F{n}"),
+        KeyCodeName::Enter => "Enter".to_string(),
+        KeyCodeName::Esc => "Esc".to_string(),
+        KeyCodeName::Tab => "Tab".to_string(),
+        KeyCodeName::BackTab => "Shift+Tab".to_string(),
+        KeyCodeName::Insert => "Insert".to_string(),
+        KeyCodeName::Space => "Space".to_string(),
+        KeyCodeName::Left => "Left".to_string(),
+        KeyCodeName::Right => "Right".to_string(),
+        KeyCodeName::Up => "Up".to_string(),
+        KeyCodeName::Down => "Down".to_string(),
+        KeyCodeName::PageUp => "PageUp".to_string(),
+        KeyCodeName::PageDown => "PageDown".to_string(),
+        KeyCodeName::Home => "Home".to_string(),
+        KeyCodeName::End => "End".to_string(),
+    };
+    if code == "Shift+Tab" {
+        if parts.is_empty() { return code; }
+        return format!("{}+{}", parts.join("+"), code);
+    }
+    parts.push(code);
+    parts.join("+")
+}
+

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -76,6 +76,7 @@ mod height_manager;
 mod transcript_app;
 mod clipboard_paste;
 mod greeting;
+pub mod keys;
 // Upstream introduced a standalone status indicator widget. Our fork renders
 // status within the composer title; keep the module private unless tests need it.
 mod status_indicator_widget;


### PR DESCRIPTION
- Add KeyChord/KeyCodeName parser; supports ctrl-g/ctrl+g/shift+enter/f-keys/pageup/pagedown (+ and - separators).
- New [tui.shortcuts] mappings for help, browser/agents HUD, transcript paging/top/bottom, composer send/history and app toggles (reasoning/screen/diffs/exit-if-empty).
- Help overlay and composer footer render configured labels (no hardcoded Ctrl+H/R/T/D).
- Wire Browser/Agents HUD toggles + transcript paging to shortcuts.
- Add tui/keys.rs for event matching and chord labels.
- Docs: codex-rs/config.md documents [tui.shortcuts] with examples.
- Tests: unit tests for KeyChord parsing in codex-core.

Notes:
- Editing keys and overlays (diff/terminal/approval/onboarding) remain static for now (phase 2).
- Snapshots remain stable with default shortcuts.
