### PR TITLE
[exit-quit-alias-113] docs(tui): document quit aliases (`/exit`, plain `exit`/`quit`)

### DIFF
--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -17,7 +17,7 @@ Notes
 - `/chrome`: connect to Chrome.
 - `/new`: start a new chat during a conversation.
 - `/resume`: resume a past session for this folder.
-- `/quit`: exit Codex.
+- `/quit`: exit Codex. Aliases: `/exit`, and plain `exit` or `quit` (no slash, any case).
 - `/logout`: log out of Codex.
 
 ## Workspace & Git


### PR DESCRIPTION
This PR updates the user docs to reflect the current TUI behavior for quitting:

- `/quit` exits Code.
- Aliases now include `/exit`, and plain `exit` or `quit` (no slash, any case) — these map to `/quit` and cleanly close the app instead of being sent to the model.

Rationale

- Matches expectations from Issue #113 (quality-of-life: make `exit` behave like a terminal) and the already-landed implementation in `codex-rs/tui/src/slash_command.rs`.
- Keeps the public documentation in sync with the shipped behavior so users discover it easily.

Validation

- No code changes; docs only. Verified implementation exists by searching and reviewing:
  - `codex-rs/tui/src/slash_command.rs:161` handles both plain `exit`/`quit` and `/exit`, normalizing to `/quit`.
- No build impact.

Refs: #113
---
Auto-generated for issue #113 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: exit-quit-alias-113 -->