### PR TITLE
[codex-optional-docs] docs(config): remove Codex from default subagent lists to allow Claude/Gemini as primary

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -136,21 +136,21 @@ file-opener = "vscode"  # Options: vscode, vscode-insiders, windsurf, cursor, no
 [[subagents.commands]]
 name = "plan"
 read-only = true
-agents = ["claude", "gemini", "qwen", "codex"]
+agents = ["claude", "gemini", "qwen"]
 orchestrator-instructions = "Focus on discovering project layout and risks. Prefer small, verifiable steps."
 agent-instructions = "Summarize assumptions explicitly. Cite files you read."
 
 [[subagents.commands]]
 name = "solve"
 read-only = true
-agents = ["claude", "gemini", "qwen", "codex"]
+agents = ["claude", "gemini", "qwen"]
 orchestrator-instructions = "Run multiple approaches in parallel and compare. Defer cancellation until a tested fix exists."
 agent-instructions = "Propose a concrete fix with steps to validate."
 
 [[subagents.commands]]
 name = "code"
 read-only = false
-agents = ["claude", "gemini", "qwen", "codex"]
+agents = ["claude", "gemini", "qwen"]
 orchestrator-instructions = "Coordinate implementations across agents; surface worktree locations and branches."
 agent-instructions = "Write minimal, focused changes with clear rationale. Include test or validation steps."
 


### PR DESCRIPTION
Summary
- Remove Codex from the default subagent model lists in `config.toml.example` so users can run multi‑agent commands with Claude and Gemini (and Qwen) without requiring Codex.

Rationale
- Issue #207 requested removing a perceived Codex requirement for the “main model.” Core already supports non‑OpenAI providers via `model_providers` in `~/.code/config.toml`, and external CLIs (Claude/Gemini) as agents.
- The example config previously listed `codex` alongside `claude`, `gemini`, and `qwen` for the built‑in subagent commands (`plan`, `solve`, `code`). This could imply Codex is required. Making the examples default to `["claude", "gemini", "qwen"]` clarifies that Codex is optional.

Changes
- config.toml.example
  - Update `[[subagents.commands]]` for `plan`, `solve`, and `code`:
    - Before: `agents = ["claude", "gemini", "qwen", "codex"]`
    - After:  `agents = ["claude", "gemini", "qwen"]`

Notes
- No Rust code changes were needed; the core already allows alternate providers/agents. This is a minimal, safe change focused on defaults and guidance.

Validation
- Built locally with `./build-fast.sh` (no errors, no warnings).
- Verified that the change only affects the example config and does not alter runtime behavior unless the example is adopted by users.

Follow‑ups (optional)
- If desired, we can add a short snippet to `docs/config.md#model_providers` linking a generic example for setting a custom provider (OpenAI‑compatible proxy) and reiterate that Codex is optional as an agent.
---
Auto-generated for issue #207 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: codex-optional-docs -->