### PR TITLE
Fix nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746844454,
-        "narHash": "sha256-GcUWDQUDRYrD34ol90KGUpjbVcOfUNbv0s955jPecko=",
+        "lastModified": 1758508617,
+        "narHash": "sha256-kx2uELmVnAbiekj/YFfWR26OXqXedImkhe2ocnbumTA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "be092436d4c0c303b654e4007453b69c0e33009e",
+        "rev": "d2bac276ac7e669a1f09c48614538a37e3eb6d0f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,17 +30,20 @@
           inherit monorepo-deps;
         };
       in
-      rec {
+      {
         packages = {
           codex-rs = codex-rs.package;
+          default = codex-rs.package;
         };
 
         devShells = {
           codex-rs = codex-rs.devShell;
+          default = codex-rs.devShell;
         };
 
         apps = {
           codex-rs = codex-rs.app;
+          default = codex-rs.app;
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -25,9 +25,6 @@
           pnpm
           husky
         ];
-        codex-cli = import ./codex-cli {
-          inherit pkgs monorepo-deps;
-        };
         codex-rs = import ./codex-rs {
           pkgs = pkgsWithRust;
           inherit monorepo-deps;
@@ -35,23 +32,16 @@
       in
       rec {
         packages = {
-          codex-cli = codex-cli.package;
           codex-rs = codex-rs.package;
         };
 
         devShells = {
-          codex-cli = codex-cli.devShell;
           codex-rs = codex-rs.devShell;
         };
 
         apps = {
-          codex-cli = codex-cli.app;
           codex-rs = codex-rs.app;
         };
-
-        defaultPackage = packages.codex-cli;
-        defaultApp = apps.codex-cli;
-        defaultDevShell = devShells.codex-cli;
       }
     );
 }


### PR DESCRIPTION
I dropped the build of the old cli from the flake, where the default.nix already seemed to removed in a previous iterations. Then I updated flake.nix and codex-rs expression to be able to build again (see individual commits for details).

Tested by running the following builds:


```
$ nix build .#packages.x86_64-linux.codex-rs
$ nix build .#packages.aarch64-darwin.codex-cli
```

Same as in https://github.com/openai/codex/pull/4048