### PR TITLE
[warp-text-shortcuts] fix(tui/input): robust Cmd/Option shortcuts in Warp by using SUPER modifier

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -325,27 +325,21 @@ impl TextArea {
             // Cmd+Left  -> move to beginning of line
             // Cmd+Right -> move to end of line
             // Cmd+Backspace -> delete entire current line contents
-            #[allow(unreachable_patterns)]
             KeyEvent { code: KeyCode::Left, modifiers, .. }
-                if modifiers.bits() & (KeyModifiers::ALT | KeyModifiers::CONTROL).bits() == 0
-                    && { #[allow(deprecated)] { modifiers.bits() & (crossterm::event::KeyModifiers::from_bits_truncate(0b0000_1000).bits()) } } != 0 =>
+                if modifiers.contains(KeyModifiers::SUPER)
+                    && !modifiers.intersects(KeyModifiers::ALT | KeyModifiers::CONTROL) =>
             {
-                // Treat unknown extra modifier bit (commonly SUPER/Cmd) as line home.
                 self.move_cursor_to_beginning_of_line(false);
             }
-            #[allow(unreachable_patterns)]
             KeyEvent { code: KeyCode::Right, modifiers, .. }
-                if modifiers.bits() & (KeyModifiers::ALT | KeyModifiers::CONTROL).bits() == 0
-                    && { #[allow(deprecated)] { modifiers.bits() & (crossterm::event::KeyModifiers::from_bits_truncate(0b0000_1000).bits()) } } != 0 =>
+                if modifiers.contains(KeyModifiers::SUPER)
+                    && !modifiers.intersects(KeyModifiers::ALT | KeyModifiers::CONTROL) =>
             {
-                // Treat unknown extra modifier bit (commonly SUPER/Cmd) as line end.
                 self.move_cursor_to_end_of_line(false);
             }
-            #[allow(unreachable_patterns)]
             KeyEvent { code: KeyCode::Backspace, modifiers, .. }
-                if { #[allow(deprecated)] { modifiers.bits() & (crossterm::event::KeyModifiers::from_bits_truncate(0b0000_1000).bits()) } } != 0 =>
+                if modifiers.contains(KeyModifiers::SUPER) =>
             {
-                // Treat Cmd+Backspace as delete entire line contents.
                 self.delete_entire_line();
             }
             // Meta-b -> move to beginning of previous word


### PR DESCRIPTION
Summary

- Replace brittle Cmd (SUPER) detection with crossterm’s `KeyModifiers::SUPER` in the composer `TextArea` so macOS/Warp.dev shortcuts work reliably.
- Keeps existing Option/Alt word navigation and deletion behavior and supports Shift+Enter for newline.

What changed

- File: `codex-rs/tui/src/bottom_pane/textarea.rs`
  - Replaced deprecated bit‑mask hack (`from_bits_truncate(0b0000_1000)`) with explicit checks for `KeyModifiers::SUPER`.
  - Behaviors now consistently recognized across terminals (including Warp):
    - Cmd+Left → move to beginning of line
    - Cmd+Right → move to end of line
    - Cmd+Backspace → delete entire line
    - Option+Left/Right → word-wise navigation (prev/next)
    - Option+Backspace → delete previous word (Option+Delete forward delete also supported)
    - Shift+Enter → insert newline in the composer

Why

- Issue #230 requested Warp.dev macOS editing shortcuts. Warp forwards the Command key as SUPER; using the enum directly is the correct, portable approach vs. relying on unknown extra bits.

Validation

- Ran `./build-fast.sh` from repo root: build completed successfully with no warnings.
- Manually reviewed input paths:
  - Composer routes key events to `TextArea::input`, which now matches Cmd via `KeyModifiers::SUPER`.
  - Enter handling in `TextArea` already inserts a newline regardless of modifiers; composer submits only on Enter without modifiers, so Shift+Enter continues to produce a newline.

Notes

- Change is minimal and localized to the input handler; no UI, protocol, or workflow changes.
---
Auto-generated for issue #230 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: warp-text-shortcuts -->