### PR TITLE
[background-bash-mode] feat(tui/bash): add background bash (!, /bash) and /bashes list+kill

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1259,6 +1259,16 @@ impl App<'_> {
                     };
 
                     match command {
+                        SlashCommand::Bash => {
+                            if let AppState::Chat { widget } = &mut self.app_state {
+                                widget.handle_background_bash_command(command_args);
+                            }
+                        }
+                        SlashCommand::Bashes => {
+                            if let AppState::Chat { widget } = &mut self.app_state {
+                                widget.handle_bashes_command(command_args);
+                            }
+                        }
                         SlashCommand::Branch => {
                             if let AppState::Chat { widget } = &mut self.app_state {
                                 widget.handle_branch_command(command_args);

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -40,6 +40,8 @@ pub enum SlashCommand {
     Validation,
     Mcp,
     Resume,
+    Bash,
+    Bashes,
     // Prompt-expanding commands
     Plan,
     Solve,
@@ -57,6 +59,8 @@ impl SlashCommand {
             SlashCommand::Chrome => "connect to Chrome",
             SlashCommand::Browser => "open internal browser",
             SlashCommand::Resume => "resume a past session for this folder",
+            SlashCommand::Bash => "run a bash command in background (! <cmd>)",
+            SlashCommand::Bashes => "list background bash tasks; supports: '/bashes kill <id>'",
             SlashCommand::Plan => "create a comprehensive plan (multiple agents)",
             SlashCommand::Solve => "solve a challenging problem (multiple agents)",
             SlashCommand::Code => "perform a coding task (multiple agents)",
@@ -108,7 +112,7 @@ impl SlashCommand {
     pub fn requires_arguments(self) -> bool {
         matches!(
             self,
-            SlashCommand::Plan | SlashCommand::Solve | SlashCommand::Code
+            SlashCommand::Plan | SlashCommand::Solve | SlashCommand::Code | SlashCommand::Bash
         )
     }
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -20,6 +20,10 @@ Notes
 - `/quit`: exit Codex.
 - `/logout`: log out of Codex.
 
+Shortcuts
+
+- `! <bash command>`: run a bash command in the background from the current working directory (returns immediately with a task id). See `/bashes`.
+
 ## Workspace & Git
 
 - `/init`: create an `AGENTS.md` file with instructions for Codex.
@@ -30,6 +34,8 @@ Notes
 - `/merge`: merge the current worktree branch back into the default branch and
   remove the worktree. Run this from inside the worktree created by `/branch`.
 - `/cmd <name>`: run a project command defined for the current workspace.
+- `/bash <command>`: run a bash command in the background (same as `! <command>`).
+- `/bashes [kill <id>]`: list background bash tasks; use `kill <id>` to force quit a running task.
 
 ## UX & Display
 


### PR DESCRIPTION
### Summary
Adds a lightweight Background Bash Mode to the TUI and a companion listing command:

- `! <command>` — run a bash command in the background from the current working directory (returns immediately)
- `/bash <command>` — same as `! <command>`
- `/bashes` — list background bash tasks with status and durations
- `/bashes kill <id>` — force quit a running background task by id

This mirrors the Claude Code experience while fitting the existing Code architecture (Terminal runs + History cells) with minimal, focused changes.

### Details
- New slash commands in `codex-rs/tui/src/slash_command.rs`:
  - `bash` (“run a bash command in background”) and `bashes` (“list/kill background tasks”).
- Chat input shortcuts in `codex-rs/tui/src/chatwidget.rs`:
  - Recognizes leading `!` to dispatch a background bash immediately.
- Background tasks run via the existing Terminal runner path, but without opening the terminal overlay:
  - We allocate a run id, spawn `[/bin/bash, -lc, <script>]`, and track it in a new in‑memory map.
  - Start/end notifications are inserted as background events in history.
  - `/bashes` composes a simple status view; `kill <id>` maps to TerminalCancel for that run.
- Docs updated: `docs/slash-commands.md` now lists `!`, `/bash`, and `/bashes`.

Notes:
- Tasks inherit the TUI’s current working directory (useful in /branch worktrees). The start notice shows the path explicitly.
- We intentionally do not surface live output in history to keep runs non‑intrusive; users can continue chatting while commands execute.
- Keyboard shortcut `Ctrl+B` is not wired in this PR to keep the diff minimal; it can be added as a follow‑up if desired.

### Validation
- Built locally with `./build-fast.sh`; zero errors and zero warnings.
- Manual sanity checks:
  - `! sleep 1 && echo done` → immediate ack with id; `/bashes` shows running then completed; exit event recorded.
  - `/bash echo hi` → same behavior as `! echo hi`.
  - `/bashes kill <id>` → sends cancel; exit recorded.

### Rationale
Implements Issue #232 requested parity with Claude Code background commands while aligning with Code’s existing Terminal execution/event model and history UX. Changes are localized and avoid broader protocol updates.
---
Auto-generated for issue #232 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: background-bash-mode -->