### PR TITLE
[sandbox-write-approval] fix(core/safety): ask for approval for apply_patch in read-only instead of hard reject

### DIFF
--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -31,11 +31,14 @@ pub fn assess_patch_safety(
         };
     }
 
-    // In Read Only mode, write operations are not permitted. Reject immediately
-    // so the agent receives a clear failure without prompting for approval.
+    // In Read Only mode, writing requires explicit approval. Ask the user
+    // instead of hard-rejecting so a one-time approval can proceed.
     if matches!(sandbox_policy, SandboxPolicy::ReadOnly) {
-        return SafetyCheck::Reject {
-            reason: "write operations are disabled in read-only mode".to_string(),
+        return match policy {
+            AskForApproval::Never => SafetyCheck::Reject {
+                reason: "write operations are disabled in read-only mode".to_string(),
+            },
+            _ => SafetyCheck::AskUser,
         };
     }
 


### PR DESCRIPTION
### Summary
Fixes issue #235 where any patch attempts in a read‑only sandbox immediately failed with a rejection message instead of prompting for escalated permissions.

### Root Cause
`assess_patch_safety()` in `codex-core` returned `Reject` for any patch when the sandbox mode was `ReadOnly`:
- This short‑circuited the normal approval flow, so the UI never had a chance to ask the user for permission and elevate the operation.
- As a result, models printed guidance about being blocked rather than issuing an approval request and applying the patch.

### Change
- In `codex-rs/core/src/safety.rs`, change the `ReadOnly` handling for patches from `Reject { reason: … }` to `AskUser`.
- This allows the UI to present an approval prompt and, once approved, proceed to apply the patch via client tools or an unsandboxed path as configured.

### Why this is safe and minimal
- The change is narrowly scoped to patch safety assessment in read‑only mode; no other approval or sandbox logic was altered.
- Builds do not introduce new warnings or APIs; behavior simply aligns with the expected UX: “ask, approve, apply”.

### Validation
- Built the repo with `./build-fast.sh` (required check): succeeded with no warnings or errors.
- Sanity: Verified code paths for patch approval requests remain intact in MCP server and TUI.

### Notes / Follow‑ups
- Delete/rename operations inside `apply_patch` still execute some filesystem calls directly. In most common flows (adds/updates) the client tools handle writes outside the sandbox after approval. If we see further reports specific to delete/rename under strict sandboxes, we can extend the client‑tool file operations to include delete/move for complete parity.
---
Auto-generated for issue #235 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: sandbox-write-approval -->