### PR TITLE
[ctrl-a-conflict] fix(tui): shift agents shortcut to ctrl+shift+a

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3078,7 +3078,7 @@ impl ChatWidget<'_> {
 
         // Global HUD toggles (avoid conflicting with common editor keys):
         // - Ctrl+B: toggle Browser panel (expand/collapse)
-        // - Ctrl+A: toggle Agents terminal mode
+        // - Ctrl+Shift+A: toggle Agents terminal mode
         if let KeyEvent {
             code: crossterm::event::KeyCode::Char('b'),
             modifiers: crossterm::event::KeyModifiers::CONTROL,
@@ -3091,13 +3091,17 @@ impl ChatWidget<'_> {
         }
         if let KeyEvent {
             code: crossterm::event::KeyCode::Char('a'),
-            modifiers: crossterm::event::KeyModifiers::CONTROL,
+            modifiers,
             kind: KeyEventKind::Press | KeyEventKind::Repeat,
             ..
         } = key_event
         {
-            self.toggle_agents_hud();
-            return;
+            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                && modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
+            {
+                self.toggle_agents_hud();
+                return;
+            }
         }
 
         if self.agents_terminal.active {
@@ -9195,7 +9199,7 @@ impl ChatWidget<'_> {
             t_fg.add_modifier(Modifier::BOLD),
         )]));
         lines.push(kv("Ctrl+B", "Toggle Browser panel"));
-        lines.push(kv("Ctrl+A", "Open Agents terminal"));
+        lines.push(kv("Ctrl+Shift+A", "Open Agents terminal"));
 
         // Slash command reference
         lines.push(RtLine::from(""));
@@ -16311,9 +16315,9 @@ impl ChatWidget<'_> {
         left_spans.push(Span::raw(" "));
         left_spans.push(Span::raw(summary));
 
-        // Right side: hint for opening terminal (Ctrl+A)
+        // Right side: hint for opening terminal (Ctrl+Shift+A)
         let right_spans: Vec<Span> = vec![
-            Span::from("Ctrl+A").style(key_hint_style),
+            Span::from("Ctrl+Shift+A").style(key_hint_style),
             Span::styled(" open terminal", label_style),
         ];
 
@@ -16379,7 +16383,10 @@ impl ChatWidget<'_> {
 
         let title_spans = vec![
             Span::styled(" Agents ", Style::default().fg(crate::colors::text())),
-            Span::styled("— Ctrl+A to close", Style::default().fg(crate::colors::text_dim())),
+            Span::styled(
+                "— Ctrl+Shift+A to close",
+                Style::default().fg(crate::colors::text_dim()),
+            ),
         ];
 
         let block = Block::default()
@@ -16817,7 +16824,7 @@ impl ChatWidget<'_> {
         left_spans.push(Span::raw(" "));
         left_spans.push(Span::raw(summary));
         let right_spans: Vec<Span> = vec![
-            Span::from("Ctrl+A").style(key_hint_style),
+            Span::from("Ctrl+Shift+A").style(key_hint_style),
             Span::styled(" open terminal", label_style),
         ];
         let measure =

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -486,9 +486,15 @@ fn agents_terminal_toggle_via_shortcuts() {
     assert!(chat.agents_terminal.order.contains(&"agent-1".to_string()));
     assert!(!chat.agents_terminal.active);
 
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL));
+    chat.handle_key_event(KeyEvent::new(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    ));
     pump_app_events(&mut chat, &rx);
-    assert!(chat.agents_terminal.active, "Ctrl+A should open terminal");
+    assert!(
+        chat.agents_terminal.active,
+        "Ctrl+Shift+A should open terminal"
+    );
 
     // Esc should exit the terminal view
     chat.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -521,7 +527,10 @@ fn agents_terminal_focus_and_scroll_controls() {
         msg: EventMsg::AgentStatusUpdate(event),
     });
 
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL));
+    chat.handle_key_event(KeyEvent::new(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    ));
     pump_app_events(&mut chat, &rx);
     assert_eq!(chat.agents_terminal.focus(), AgentsTerminalFocus::Sidebar);
 
@@ -571,7 +580,10 @@ fn agents_terminal_esc_closes_from_sidebar() {
         msg: EventMsg::AgentStatusUpdate(event),
     });
 
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL));
+    chat.handle_key_event(KeyEvent::new(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    ));
     pump_app_events(&mut chat, &rx);
     assert!(chat.agents_terminal.active, "overlay should open");
     assert_eq!(chat.agents_terminal.focus(), AgentsTerminalFocus::Sidebar);


### PR DESCRIPTION
## Summary

- switch the agents terminal toggle to `Ctrl+Shift+A` to avoid the default macOS `Ctrl+A` navigation
- refresh the shortcut hints and tests to reference the new chord

## Testing

- ./build-fast.sh
---
Auto-generated for issue #255 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: ctrl-a-conflict -->