### PR TITLE
[resume-on-exit] feat(cli): surface session resume hint on exit

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -257,9 +257,18 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 &mut interactive.config_overrides,
                 root_config_overrides.clone(),
             );
-            let usage = codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
-            if !usage.is_zero() {
-                println!("{}", codex_core::protocol::FinalOutput::from(usage));
+            let summary = codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            if !summary.token_usage.is_zero() {
+                println!(
+                    "{}",
+                    codex_core::protocol::FinalOutput::from(summary.token_usage.clone())
+                );
+            }
+            if let Some(session_id) = summary.session_id {
+                println!(
+                    "To continue this session, run codex resume {}.",
+                    session_id
+                );
             }
         }
         Some(Subcommand::Exec(mut exec_cli)) => {
@@ -287,7 +296,19 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 last,
                 config_overrides,
             );
-            codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            let summary = codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            if !summary.token_usage.is_zero() {
+                println!(
+                    "{}",
+                    codex_core::protocol::FinalOutput::from(summary.token_usage.clone())
+                );
+            }
+            if let Some(session_id) = summary.session_id {
+                println!(
+                    "To continue this session, run codex resume {}.",
+                    session_id
+                );
+            }
         }
         Some(Subcommand::Login(mut login_cli)) => {
             prepend_config_flags(

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -45,6 +45,7 @@ use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::oneshot;
+use uuid::Uuid;
 
 /// Time window for debouncing redraw requests.
 ///
@@ -2560,6 +2561,13 @@ impl App<'_> {
                 }
                 _ => screen.handle_key_event(key_event),
             },
+        }
+    }
+
+    pub(crate) fn session_id(&self) -> Option<Uuid> {
+        match &self.app_state {
+            AppState::Chat { widget } => widget.session_id(),
+            AppState::Onboarding { .. } => None,
         }
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -13792,6 +13792,10 @@ impl ChatWidget<'_> {
         self.pending_agent_notes.push(note);
     }
 
+    pub(crate) fn session_id(&self) -> Option<uuid::Uuid> {
+        self.session_id
+    }
+
     pub(crate) fn token_usage(&self) -> &TokenUsage {
         &self.total_token_usage
     }

--- a/codex-rs/tui/src/main.rs
+++ b/codex-rs/tui/src/main.rs
@@ -22,10 +22,18 @@ fn main() -> anyhow::Result<()> {
             .config_overrides
             .raw_overrides
             .splice(0..0, top_cli.config_overrides.raw_overrides);
-        let usage = run_main(inner, codex_linux_sandbox_exe).await?;
-        if !usage.is_zero() {
-            println!("{}", codex_core::protocol::FinalOutput::from(usage));
-            // Conversation id hint not available in fork run_main() return type.
+        let summary = run_main(inner, codex_linux_sandbox_exe).await?;
+        if !summary.token_usage.is_zero() {
+            println!(
+                "{}",
+                codex_core::protocol::FinalOutput::from(summary.token_usage.clone())
+            );
+        }
+        if let Some(session_id) = summary.session_id {
+            println!(
+                "To continue this session, run codex resume {}.",
+                session_id
+            );
         }
         Ok(())
     })


### PR DESCRIPTION
## Summary
- add a `RunSummary` struct so the TUI returns the session id alongside the token usage
- print the "codex resume <id>" hint from both the CLI entrypoint and the standalone TUI binary
- expose the current session id from the TUI `App`/`ChatWidget`

## Testing
- ./build-fast.sh
---
Auto-generated for issue #258 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: resume-on-exit -->