### PR TITLE
fix(tui): pass session config into auto coordinator

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -9415,6 +9415,7 @@ impl ChatWidget<'_> {
             self.app_event_tx.clone(),
             goal_text.clone(),
             conversation,
+            self.config.clone(),
             self.config.debug,
         ) {
             Ok(handle) => {


### PR DESCRIPTION
## Summary
- pass the active session configuration into the auto coordinator worker
- reuse the provided config when building the auto loop client so workspace changes are honored

## Testing
- ./build-fast.sh

------
https://chatgpt.com/codex/tasks/task_e_68d898ff0980832a8147ed3ee79a110b