### PR TITLE
[powershell-apply-patch] fix: force apply_patch function tool on Windows families

### DIFF
--- a/code-rs/core/src/client_common.rs
+++ b/code-rs/core/src/client_common.rs
@@ -112,10 +112,13 @@ impl Prompt {
             OpenAiTool::Freeform(f) => f.name == "apply_patch",
             _ => false,
         });
-        if self.base_instructions_override.is_none()
-            && effective_model.needs_special_apply_patch_instructions
-            && !is_apply_patch_tool_present
-        {
+        if self.base_instructions_override.is_some() {
+            return Cow::Borrowed(base);
+        }
+
+        let should_append_apply_patch =
+            effective_model.needs_special_apply_patch_instructions || !is_apply_patch_tool_present;
+        if should_append_apply_patch {
             Cow::Owned(format!("{base}\n{APPLY_PATCH_TOOL_INSTRUCTIONS}"))
         } else {
             Cow::Borrowed(base)

--- a/code-rs/core/src/model_family.rs
+++ b/code-rs/core/src/model_family.rs
@@ -96,9 +96,17 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
     } else if slug.starts_with("gpt-oss") || slug.starts_with("openai/gpt-oss") {
         model_family!(slug, "gpt-oss", apply_patch_tool_type: Some(ApplyPatchToolType::Function))
     } else if slug.starts_with("gpt-4o") {
-        model_family!(slug, "gpt-4o", needs_special_apply_patch_instructions: true)
+        model_family!(
+            slug, "gpt-4o",
+            needs_special_apply_patch_instructions: true,
+            apply_patch_tool_type: Some(ApplyPatchToolType::Function),
+        )
     } else if slug.starts_with("gpt-3.5") {
-        model_family!(slug, "gpt-3.5", needs_special_apply_patch_instructions: true)
+        model_family!(
+            slug, "gpt-3.5",
+            needs_special_apply_patch_instructions: true,
+            apply_patch_tool_type: Some(ApplyPatchToolType::Function),
+        )
     } else if slug.starts_with("codex-") || slug.starts_with("gpt-5-codex") {
         model_family!(
             slug, slug,


### PR DESCRIPTION
## Summary
- ensure Windows model families default to the function-based apply_patch tool so PowerShell works without heredocs
- always append the apply_patch instructions when using the default instruction set and the tool is missing, matching GPT-5 requirements

## Testing
- ./build-fast.sh
---
Auto-generated for issue #329 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: powershell-apply-patch -->