### PR TITLE
[default-dark-mode] feat(tui/theme): default to dark theme by default

### DIFF
--- a/code-rs/core/src/config_types.rs
+++ b/code-rs/core/src/config_types.rs
@@ -868,11 +868,10 @@ pub struct HighlightConfig {
 }
 
 /// Available predefined themes
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ThemeName {
     // Light themes (at top)
-    #[default]
     LightPhoton,
     LightPhotonAnsi16,
     LightPrismRainbow,
@@ -891,6 +890,10 @@ pub enum ThemeName {
     DarkZenGarden,
     DarkPaperLightPro,
     Custom,
+}
+
+impl Default for ThemeName {
+    fn default() -> Self { ThemeName::DarkCarbonNight }
 }
 
 /// Theme colors that can be customized

--- a/code-rs/tui/src/lib.rs
+++ b/code-rs/tui/src/lib.rs
@@ -570,7 +570,7 @@ fn maybe_apply_terminal_theme_detection(config: &mut Config, theme_configured_ex
         return;
     }
 
-    if theme.name != ThemeName::LightPhoton {
+    if theme.name != ThemeName::default() {
         return;
     }
 
@@ -646,8 +646,9 @@ fn apply_detected_theme(theme: &mut ThemeConfig, is_dark: bool) {
             "Detected dark terminal background; switching default theme to Dark - Carbon Night"
         );
     } else {
+        theme.name = ThemeName::LightPhoton;
         tracing::info!(
-            "Detected light terminal background; keeping default Light - Photon theme"
+            "Detected light terminal background; switching default theme to Light - Photon"
         );
     }
 }

--- a/code-rs/tui/src/theme.rs
+++ b/code-rs/tui/src/theme.rs
@@ -9,7 +9,7 @@ use std::sync::RwLock;
 
 lazy_static! {
     static ref CURRENT_THEME: RwLock<Theme> = RwLock::new(Theme::default());
-    static ref CURRENT_THEME_NAME: RwLock<ThemeName> = RwLock::new(ThemeName::LightPhoton);
+    static ref CURRENT_THEME_NAME: RwLock<ThemeName> = RwLock::new(ThemeName::default());
     static ref CUSTOM_THEME_LABEL: RwLock<Option<String>> = RwLock::new(None);
     static ref CUSTOM_THEME_COLORS: RwLock<Option<code_core::config_types::ThemeColors>> = RwLock::new(None);
     static ref CUSTOM_THEME_IS_DARK: RwLock<Option<bool>> = RwLock::new(None);
@@ -54,7 +54,7 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        get_predefined_theme(ThemeName::LightPhoton)
+        get_predefined_theme(ThemeName::default())
     }
 }
 


### PR DESCRIPTION
## Summary

- switch the default `ThemeName` enum variant to `DarkCarbonNight`
- ensure the TUI theme cache initializes from that new default via `Theme::default`
- adjust terminal autodetect logging to explicitly set the light theme when needed

## Testing

- ./build-fast.sh
---
Auto-generated for issue #332 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: default-dark-mode -->