### PR TITLE
[nix-flake-install-fix] fix(nix): add ratatui output hash for flake install

### DIFF
--- a/code-rs/default.nix
+++ b/code-rs/default.nix
@@ -9,7 +9,12 @@ rec {
     inherit env;
     pname = "code-rs";
     version = "0.1.0";
-    cargoLock.lockFile = ./Cargo.lock;
+    cargoLock = {
+      lockFile = ./Cargo.lock;
+      outputHashes = {
+        "ratatui-0.29.0" = "sha256-slLAIUXlq7/BcEZniLvutTozZfy8ilYh8o95ut0fanA=";
+      };
+    };
     doCheck = false;
     src = ./.;
     nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
## Summary
- add `cargoLock.outputHashes` entry for the git-based ratatui so nix can vendor the dependency
- keep the flake wiring unchanged otherwise because the lockfile already pins the fork commit

## Testing
- ./build-fast.sh
---
Auto-generated for issue #338 by a workflow.
Author: @github-actions[bot]
<!-- codex-id: nix-flake-install-fix -->