### PR TITLE
fix(ci): install musl targets for preview build

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -63,15 +63,22 @@ jobs:
       - name: Install Rust toolchain
         shell: bash
         run: |
+          TOOLCHAIN=1.90.0
           rustup set profile minimal
-          rustup toolchain install 1.89.0 --profile minimal --target ${{ matrix.target }}
-          rustup default 1.89.0
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+          rustup default "$TOOLCHAIN"
+
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+          fi
+
+          rustup target add "${{ matrix.target }}"
 
       - name: Rust cache (target + registries)
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-preview
-          shared-key: preview-${{ matrix.target }}-rust-1.89
+          shared-key: preview-${{ matrix.target }}-rust-1.90
           workspaces: |
             code-rs -> target
             codex-rs -> target


### PR DESCRIPTION
## Summary
- pin the preview build workflow to Rust 1.90.0 (matching rust-toolchain.toml)
- install the musl cross targets alongside the matrix target so cargo can locate core

Fixes #355

## Testing
- n/a (workflow change)
