### PR TITLE
fix(sandbox): keep full-auto workspace-writable

### DIFF
--- a/code-rs/core/src/codex.rs
+++ b/code-rs/core/src/codex.rs
@@ -167,12 +167,13 @@ fn to_proto_sandbox_policy(policy: SandboxPolicy) -> ProtoSandboxPolicy {
             network_access,
             exclude_tmpdir_env_var,
             exclude_slash_tmp,
-            allow_git_writes: _,
+            allow_git_writes,
         } => ProtoSandboxPolicy::WorkspaceWrite {
             writable_roots,
             network_access,
             exclude_tmpdir_env_var,
             exclude_slash_tmp,
+            allow_git_writes,
         },
     }
 }

--- a/code-rs/protocol/src/protocol.rs
+++ b/code-rs/protocol/src/protocol.rs
@@ -271,8 +271,15 @@ pub enum SandboxPolicy {
         /// writable roots on UNIX. Defaults to `false`.
         #[serde(default)]
         exclude_slash_tmp: bool,
+
+        /// When true, do not protect the top-level `.git` folder under a writable root.
+        /// Defaults to true to match historical behavior that permits Git writes.
+        #[serde(default = "default_true_bool")]
+        allow_git_writes: bool,
     },
 }
+
+const fn default_true_bool() -> bool { true }
 
 /// A writable root path accompanied by a list of subpaths that should remain
 /// read‑only even when the root is writable. This is primarily used to ensure
@@ -328,6 +335,7 @@ impl SandboxPolicy {
             network_access: false,
             exclude_tmpdir_env_var: false,
             exclude_slash_tmp: false,
+            allow_git_writes: true,
         }
     }
 
@@ -363,6 +371,7 @@ impl SandboxPolicy {
                 writable_roots,
                 exclude_tmpdir_env_var,
                 exclude_slash_tmp,
+                allow_git_writes,
                 network_access: _,
             } => {
                 // Start from explicitly configured writable roots.
@@ -400,9 +409,11 @@ impl SandboxPolicy {
                     .into_iter()
                     .map(|writable_root| {
                         let mut subpaths = Vec::new();
-                        let top_level_git = writable_root.join(".git");
-                        if top_level_git.is_dir() {
-                            subpaths.push(top_level_git);
+                        if !allow_git_writes {
+                            let top_level_git = writable_root.join(".git");
+                            if top_level_git.is_dir() {
+                                subpaths.push(top_level_git);
+                            }
                         }
                         WritableRoot {
                             root: writable_root,

--- a/code-rs/tui/src/lib.rs
+++ b/code-rs/tui/src/lib.rs
@@ -325,7 +325,7 @@ pub async fn run_main(
     let (sandbox_mode, approval_policy) = if cli.full_auto {
         (
             Some(SandboxMode::WorkspaceWrite),
-            Some(AskForApproval::OnRequest),
+            Some(AskForApproval::OnFailure),
         )
     } else if cli.dangerously_bypass_approvals_and_sandbox {
         (


### PR DESCRIPTION
## Summary
- treat  as  so the session stays headless
- propagate  through the public SandboxPolicy wire type so  protections survive config→protocol hops

Fixes #348

## Testing
- ./build-fast.sh
- Repro:  (no extra approval prompt, workspace stays writable)
