### PR TITLE
ci: update preview build to Rust 1.90.0

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -62,16 +62,22 @@ jobs:
 
       - name: Install Rust toolchain
         shell: bash
+        env:
+          RUST_TOOLCHAIN: 1.90.0
         run: |
           rustup set profile minimal
-          rustup toolchain install 1.89.0 --profile minimal --target ${{ matrix.target }}
-          rustup default 1.89.0
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustup target add "${{ matrix.target }}"
+          if [[ "${{ matrix.target }}" == *"unknown-linux-musl"* ]]; then
+            rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+          fi
 
       - name: Rust cache (target + registries)
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-preview
-          shared-key: preview-${{ matrix.target }}-rust-1.89
+          shared-key: preview-${{ matrix.target }}-rust-1.90
           workspaces: |
             code-rs -> target
             codex-rs -> target


### PR DESCRIPTION
## Summary
- bump the preview workflow to Rust 1.90.0 across Linux, macOS, and Windows runners
- add an explicit `rustup target add` for each matrix target and ensure both musl targets are installed on Linux jobs
- update rust-cache keys to match the new toolchain version while keeping the publish job gating introduced in #359 untouched

Fixes #357
Fixes #358
Fixes #362
Fixes #363

## Testing
- ./build-fast.sh (1.90.0)