### PR TITLE
Fix agent cleanup and UI pruning

### DIFF
--- a/code-rs/core/src/codex.rs
+++ b/code-rs/core/src/codex.rs
@@ -9845,46 +9845,17 @@ async fn capture_browser_screenshot(_sess: &Session) -> Result<(PathBuf, String)
 /// Send agent status update event to the TUI
 async fn send_agent_status_update(sess: &Session) {
     let manager = AGENT_MANAGER.read().await;
+    let payload = manager.build_status_payload();
+    drop(manager);
 
-    // Collect all agents; include completed/failed so HUD can show final messages
-    let now = Utc::now();
-    let agents: Vec<crate::protocol::AgentInfo> = manager
-        .get_all_agents()
-        .map(|agent| {
-            let start = agent.started_at.unwrap_or(agent.created_at);
-            let end = agent.completed_at.unwrap_or(now);
-            let elapsed_ms = match end.signed_duration_since(start).num_milliseconds() {
-                value if value >= 0 => Some(value as u64),
-                _ => None,
-            };
-
-            crate::protocol::AgentInfo {
-                id: agent.id.clone(),
-                name: agent.model.clone(), // Use model name as the display name
-                status: match agent.status {
-                    AgentStatus::Pending => "pending".to_string(),
-                    AgentStatus::Running => "running".to_string(),
-                    AgentStatus::Completed => "completed".to_string(),
-                    AgentStatus::Failed => "failed".to_string(),
-                    AgentStatus::Cancelled => "cancelled".to_string(),
-                },
-                batch_id: agent.batch_id.clone(),
-                model: Some(agent.model.clone()),
-                last_progress: agent.progress.last().cloned(),
-                result: agent.result.clone(),
-                error: agent.error.clone(),
-                elapsed_ms,
-                token_count: None,
-            }
-        })
-        .collect();
+    let AgentStatusUpdatePayload { agents, context, task } = payload;
 
     let event = sess.make_event(
         "agent_status",
         EventMsg::AgentStatusUpdate(AgentStatusUpdateEvent {
             agents,
-            context: None,
-            task: None,
+            context,
+            task,
         }),
     );
 

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -12836,6 +12836,38 @@ impl ChatWidget<'_> {
         }
     }
 
+    pub(super) fn prune_agents_terminal_state(
+        &mut self,
+        active_agent_ids: &HashSet<String>,
+        active_batch_ids: &HashSet<String>,
+    ) {
+        self.agents_terminal
+            .entries
+            .retain(|id, _| active_agent_ids.contains(id));
+        self.agents_terminal
+            .order
+            .retain(|id| active_agent_ids.contains(id));
+        self.agents_terminal
+            .scroll_offsets
+            .retain(|key, _| {
+                if let Some(agent_id) = key.strip_prefix("agent:") {
+                    active_agent_ids.contains(agent_id)
+                } else if let Some(batch_id) = key.strip_prefix("batch:") {
+                    if batch_id == "__adhoc__" {
+                        true
+                    } else {
+                        active_batch_ids.contains(batch_id)
+                    }
+                } else {
+                    true
+                }
+            });
+        self.agents_terminal.clamp_selected_index();
+        if self.agents_terminal.active {
+            self.restore_selected_agent_scroll();
+        }
+    }
+
     fn enter_agents_terminal_mode(&mut self) {
         if self.agents_terminal.active {
             return;


### PR DESCRIPTION
## Summary
- cancel agent subprocesses when runs are stopped and avoid flipping cancelled agents to failed
- cap agent backlog by pruning completed runs and trimming terminal view state
- reuse bounded payload builder for status events so the TUI only sees active agents

<!-- codex-id: agents-cleanup -->
