### PR TITLE
fix(cli/postinstall): rerun bootstrap when scripts skipped (#369)

### DIFF
--- a/codex-cli/test/postinstall.test.js
+++ b/codex-cli/test/postinstall.test.js
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('runPostinstall resolves in dry-run mode', async () => {
+  const { runPostinstall } = await import('../postinstall.js');
+  process.env.CODE_POSTINSTALL_DRY_RUN = '1';
+  try {
+    const result = await runPostinstall({ invokedByRuntime: true, skipGlobalAlias: true });
+    assert.ok(result && result.skipped === true);
+  } finally {
+    delete process.env.CODE_POSTINSTALL_DRY_RUN;
+    delete process.env.CODE_RUNTIME_POSTINSTALL;
+  }
+});


### PR DESCRIPTION
## Summary
- export the postinstall bootstrap as `runPostinstall` and reuse it when the CLI notices missing binaries
- retry runtime bootstrap from `coder.js` when lifecycle scripts are skipped, while suppressing global alias churn
- add a dry-run unit test so we can exercise the new entry point without fetching real artifacts

## Testing
- node --test codex-cli/test/postinstall.test.js
- ./build-fast.sh

Closes #369.
