### PR TITLE
Fix agents overlay clamp panic on narrow terminals

### DIFF
--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -35631,7 +35631,11 @@ impl ChatWidget<'_> {
             body_area.width
         } else {
             let max_allowed = body_area.width.saturating_sub(30).max(18);
-            desired_sidebar.clamp(24, max_allowed)
+            if max_allowed < 24 {
+                max_allowed
+            } else {
+                desired_sidebar.clamp(24, max_allowed)
+            }
         };
 
         let constraints = if body_area.width <= sidebar_width {


### PR DESCRIPTION
## Summary\n- guard agents overlay sidebar width clamp on narrow terminals to avoid min>max panic\n- prefer /usr/bin/as when the Qumulo toolchain wrapper is on PATH to avoid ring build failures\n\n## Testing\n- ./build-fast.sh\n\nFixes #478