### PR TITLE
reduce snapshot churn and speed up HistoryId lookups

### DIFF
--- a/code-rs/core/src/cgroup.rs
+++ b/code-rs/core/src/cgroup.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "linux")]
@@ -172,24 +173,3 @@ pub(crate) fn best_effort_cleanup_exec_cgroup(pid: u32) {
     // Only remove the per-pid directory. The parent container stays.
     let _ = std::fs::remove_dir(&dir);
 }
-
-#[cfg(not(target_os = "linux"))]
-pub(crate) fn default_exec_memory_max_bytes() -> Option<u64> {
-    None
-}
-
-#[cfg(not(target_os = "linux"))]
-pub(crate) fn best_effort_attach_self_to_exec_cgroup(_pid: u32, _memory_max_bytes: u64) {}
-
-#[cfg(not(target_os = "linux"))]
-pub(crate) fn exec_cgroup_oom_killed(_pid: u32) -> Option<bool> {
-    None
-}
-
-#[cfg(not(target_os = "linux"))]
-pub(crate) fn exec_cgroup_memory_max_bytes(_pid: u32) -> Option<u64> {
-    None
-}
-
-#[cfg(not(target_os = "linux"))]
-pub(crate) fn best_effort_cleanup_exec_cgroup(_pid: u32) {}

--- a/code-rs/core/src/spawn.rs
+++ b/code-rs/core/src/spawn.rs
@@ -135,8 +135,6 @@ pub(crate) async fn spawn_child_async(
             StdioPolicy::RedirectForShellTool => crate::cgroup::default_exec_memory_max_bytes(),
             StdioPolicy::Inherit => None,
         };
-        #[cfg(not(target_os = "linux"))]
-        let exec_memory_max_bytes: Option<u64> = None;
         cmd.pre_exec(move || {
             // Start a new process group
             let _ = libc::setpgid(0, 0);

--- a/code-rs/tui/src/chatwidget/running_tools.rs
+++ b/code-rs/tui/src/chatwidget/running_tools.rs
@@ -97,7 +97,7 @@ pub(super) fn rehydrate(chat: &mut ChatWidget<'_>) {
 }
 
 pub(super) fn resolve_entry_index(
-    chat: &ChatWidget<'_>,
+    chat: &mut ChatWidget<'_>,
     entry: &RunningToolEntry,
     call_id: &str,
 ) -> Option<usize> {

--- a/code-rs/tui/src/chatwidget/tools.rs
+++ b/code-rs/tui/src/chatwidget/tools.rs
@@ -64,8 +64,9 @@ pub(super) fn mcp_end(chat: &mut ChatWidget<'_>, ev: McpToolCallEndEvent, key: O
         .remove(&map_key);
     let resolved_idx = entry_removed
         .as_ref()
-        .and_then(|entry| running_tools::resolve_entry_index(chat, entry, &call_id))
-        .or_else(|| running_tools::find_by_call_id(chat, &call_id));
+        .and_then(|entry| running_tools::resolve_entry_index(chat, entry, &call_id));
+    let resolved_idx =
+        resolved_idx.or_else(|| running_tools::find_by_call_id(chat, &call_id));
 
     if let Some(idx) = resolved_idx {
         chat.history_replace_at(idx, Box::new(completed));

--- a/code-rs/tui/src/history_cell/mod.rs
+++ b/code-rs/tui/src/history_cell/mod.rs
@@ -2242,19 +2242,6 @@ pub(crate) fn new_popular_commands_notice(
     plain_message_state_from_lines(lines, HistoryCellType::Notice)
 }
 
-/// Background status cell shown during startup while external MCP servers
-/// are being connected. Uses the standard background-event gutter (»)
-/// and inserts a blank line above the message for visual separation from
-/// the Popular commands block.
-pub(crate) fn new_connecting_mcp_status() -> BackgroundEventCell {
-    let record = BackgroundEventRecord {
-        id: HistoryId::ZERO,
-        title: String::new(),
-        description: "\nConnecting MCP servers…".to_string(),
-    };
-    BackgroundEventCell::new(record)
-}
-
 pub(crate) fn new_user_prompt(message: String) -> PlainMessageState {
     let mut lines: Vec<Line<'static>> = Vec::new();
     lines.push(Line::from("user"));


### PR DESCRIPTION
Implement fixes to address long-session TUI lag and history-state mismatch degradation.

  - Fix 1: throttle non-forced history snapshot persistence (reduce full snapshot rewrite frequency to 5 secs during rapid UI/progress updates)
  - Fix 2: add a lazy HistoryId→cell-index cache with dirty tracking + self-healing lookups; throttle “history-state mismatch” warnings; adjust tool-card/running-tool resolution to use the new lookup; add regression test to keep the index consistent under churn
  - Fix startup panic: route the “Connecting MCP servers…” notice through the background helper (avoid inserting BackgroundEvent via “prelude” path) and remove the now-unused helper
  - Cleanup: remove non-Linux cgroup stubs and adjust spawn/exec cfg blocks to eliminate macOS warnings