### PR TITLE
feat(core/agents): prepend AGENTS.md for external CLIs

### DIFF
--- a/code-rs/config.md
+++ b/code-rs/config.md
@@ -481,6 +481,9 @@ Code includes built-in support for these agents:
 - **qwen** - Qwen AI assistant (requires `qwen` CLI)
 - **cloud** - Cloud-based agents (optional, gated by `CODE_ENABLE_CLOUD_AGENT_MODEL`)
 
+Code prepends `AGENTS.md` contents (repo root to cwd, capped by `project_doc_max_bytes`)
+to external agent prompts (claude, gemini, qwen) so repo guidance is honored.
+
 ### Custom agent example
 
 ```toml


### PR DESCRIPTION
## Summary
External subagents (Claude/Gemini/Qwen CLIs) now receive repo guidance from `AGENTS.md` by default. We prepend the concatenated AGENTS.md contents (repo root → cwd, capped by `project_doc_max_bytes`) to the prompt we pass to those CLIs.

## Why
- The main Codex session obeys `AGENTS.md`, but external subagents currently don’t, which leads to inconsistent behavior across agents.
- CLI-specific context files aren’t consistent:
  - Claude doesn’t support a configurable memory filename.
  - Gemini/Qwen default to their own names (`GEMINI.md`/`QWEN.md`) and need custom config to read AGENTS.md.
- Asking users to maintain symlinks or duplicate files (`AGENTS.md` → `CLAUDE.md`/`GEMINI.md`/`QWEN.md`) is brittle.
- Prompt-level injection is deterministic and self-contained.

## Behavior
- Only affects external families: `claude`, `gemini`, `qwen`.
- Does not touch `code/codex` family (they already ingest `AGENTS.md` via core instructions).
- Uses the same max-bytes cap (`project_doc_max_bytes`) to avoid prompt bloat.

## Tests
- `./build-fast.sh`

## Questions
- Should this be default-on for external agents, or gated by a config flag?
