### PR TITLE
Clarify browser behavior for blocked local/private targets

### DIFF
--- a/code-rs/core/prompt_coder.md
+++ b/code-rs/core/prompt_coder.md
@@ -43,6 +43,7 @@ When you run shell tools with Code they will run in the foreground for up to 10 
 
 ## Browser tools
 Use the browser tools to open a live page, interact with it, and harvest results. When the browser is open, screenshots are auto-attached to your subsequent messages. The browser will either be an internal headless browser, or a CPD connection to the user's active Chrome browser. Your screenshots will be 1024×768 which exactly matches the viewport.
+In some harness environments, local/private targets (for example `localhost`, `127.0.0.1`, `10.x.x.x`, and `192.168.x.x`) are blocked by policy. When that happens, say so clearly and use a reachable public host instead of retrying the same blocked URL.
 
 ## Code Bridge
 A local Sentry-like bridge for development environments: add `@just-every/code-bridge` to your JavaScript app to stream errors/console, pageviews/screenshots, and expose a control channel for two-way, real-time debugging. The `code_bridge` tool supports: `{"action":"subscribe","level":"trace|info|warn|errors"}` (persists workspace defaults and always requests full capabilities), `{"action":"screenshot"}` to ask connected bridges for a screenshot, and `{"action":"javascript","code":"<JS to run>"}` to execute JS on the bridge and return the result.

--- a/code-rs/core/src/openai_tools.rs
+++ b/code-rs/core/src/openai_tools.rs
@@ -1913,7 +1913,7 @@ fn create_browser_tool(browser_enabled: bool) -> OpenAiTool {
         "url".to_string(),
         JsonSchema::String {
             description: Some(
-                "For action=open or fetch: URL to navigate to or retrieve (e.g., https://example.com)."
+                "For action=open or fetch: URL to navigate to or retrieve (e.g., https://example.com). Local/private targets (localhost, 127.0.0.1, RFC1918, link-local) may be blocked by policy in some environments."
                     .to_string(),
             ),
             allowed_values: None,
@@ -2059,7 +2059,7 @@ fn create_browser_tool(browser_enabled: bool) -> OpenAiTool {
 
     OpenAiTool::Function(ResponsesApiTool {
         name: "browser".to_string(),
-        description: "Unified browser controller for navigation, interaction, console access, DevTools commands, and one-shot fetches. Choose an action and supply the matching fields.".to_string(),
+        description: "Unified browser controller for navigation, interaction, console access, DevTools commands, and one-shot fetches. Choose an action and supply the matching fields. If local/private URLs are blocked by harness policy, explain that limitation and use a reachable public host instead.".to_string(),
         strict: false,
         parameters: JsonSchema::Object {
             properties,


### PR DESCRIPTION
## Summary
- add explicit browser-tool guidance that local/private URLs may be blocked by harness policy
- tell the model to clearly communicate the limitation and switch to a reachable public host
- keep this in both the developer prompt text and the browser tool schema description so the behavior is reinforced

## Validation
- `./build-fast.sh` (pass)
