### PR TITLE
fix(browser): ignore transient CDP decode errors

### DIFF
--- a/code-rs/browser/src/manager.rs
+++ b/code-rs/browser/src/manager.rs
@@ -139,6 +139,14 @@ fn should_ignore_handler_error(message_lower: &str) -> bool {
         return true;
     }
 
+    // Chromium can emit occasional CDP payloads that chromiumoxide fails to
+    // deserialize into its internal Message enum. These do not necessarily mean
+    // the browser session is unhealthy; treating them as fatal causes the
+    // manager to discard a perfectly good page right after navigation.
+    if message_lower.contains("data did not match any variant of untagged enum message") {
+        return true;
+    }
+
     // These can happen for individual targets/tabs while the overall CDP
     // connection is still healthy (e.g. tabs closing, navigations, reloads).
     const TRANSIENT_SUBSTRINGS: &[&str] = &[
@@ -2586,6 +2594,20 @@ mod tests {
             let should_stop = should_stop_handler(
                 "[test]",
                 Err(TestError("oneshot error")),
+                &mut consecutive_errors,
+            );
+            assert!(!should_stop);
+            assert_eq!(consecutive_errors, 0);
+        }
+    }
+
+    #[test]
+    fn handler_ignores_message_deserialize_errors() {
+        let mut consecutive_errors = 0u32;
+        for _ in 0..10 {
+            let should_stop = should_stop_handler(
+                "[test]",
+                Err(TestError("data did not match any variant of untagged enum Message")),
                 &mut consecutive_errors,
             );
             assert!(!should_stop);

--- a/code-rs/browser/tests/local_navigation.rs
+++ b/code-rs/browser/tests/local_navigation.rs
@@ -1,5 +1,6 @@
 use code_browser::BrowserConfig;
 use code_browser::BrowserManager;
+use std::env;
 use std::io::Read;
 use std::io::Write;
 use std::net::TcpListener;
@@ -80,6 +81,14 @@ async fn assert_manager_can_open_local_http_server(headless: bool) {
     let _ = manager.stop().await;
 }
 
+fn can_run_headed_browser_test() -> bool {
+    if !cfg!(target_os = "linux") {
+        return true;
+    }
+
+    env::var_os("DISPLAY").is_some() || env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn internal_browser_can_open_local_http_server() {
     assert_manager_can_open_local_http_server(true).await;
@@ -87,5 +96,12 @@ async fn internal_browser_can_open_local_http_server() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn headed_internal_browser_can_open_local_http_server() {
+    if !can_run_headed_browser_test() {
+        eprintln!(
+            "skipping headed browser regression test: no DISPLAY or WAYLAND_DISPLAY available"
+        );
+        return;
+    }
+
     assert_manager_can_open_local_http_server(false).await;
 }

--- a/code-rs/browser/tests/local_navigation.rs
+++ b/code-rs/browser/tests/local_navigation.rs
@@ -1,0 +1,91 @@
+use code_browser::BrowserConfig;
+use code_browser::BrowserManager;
+use std::io::Read;
+use std::io::Write;
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread;
+use std::time::Duration;
+
+fn spawn_http_server() -> (String, Arc<AtomicBool>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    listener
+        .set_nonblocking(true)
+        .expect("set non-blocking listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_thread = Arc::clone(&stop);
+
+    let handle = thread::spawn(move || {
+        while !stop_thread.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut buf = [0_u8; 2048];
+                    let _ = stream.read(&mut buf);
+                    let body = "<html><head><title>Code Browser Local Test</title></head><body><h1>browser-ok</h1></body></html>";
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(), body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    (format!("http://127.0.0.1:{}", addr.port()), stop, handle)
+}
+
+async fn assert_manager_can_open_local_http_server(headless: bool) {
+    let (url, stop, handle) = spawn_http_server();
+
+    let mut config = BrowserConfig::default();
+    config.enabled = true;
+    config.headless = headless;
+    config.idle_timeout_ms = 300_000;
+
+    let manager = BrowserManager::new(config);
+    manager.goto(&url).await.expect("navigate to local server");
+
+    let current_url = manager
+        .get_current_url()
+        .await
+        .expect("manager current url after goto");
+    assert!(current_url == url || current_url == format!("{url}/"));
+
+    let page = manager.get_or_create_page().await.expect("page after goto");
+    let href = page.inject_js("location.href").await.expect("raw href");
+    let href_text = href.as_str().unwrap_or_default();
+    assert!(href_text == url || href_text == format!("{url}/"));
+
+    let body = page
+        .execute_javascript("document.body && document.body.innerText")
+        .await
+        .expect("read page body");
+    let body_text = body
+        .get("value")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    assert!(body_text.contains("browser-ok"), "unexpected page body: {body_text}");
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = handle.join();
+    let _ = manager.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn internal_browser_can_open_local_http_server() {
+    assert_manager_can_open_local_http_server(true).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn headed_internal_browser_can_open_local_http_server() {
+    assert_manager_can_open_local_http_server(false).await;
+}

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -11068,7 +11068,13 @@ impl ChatWidget<'_> {
     /// Push a cell using a synthetic key at the TOP of the NEXT request.
     fn history_push_top_next_req(&mut self, cell: impl HistoryCell + 'static) {
         let key = self.next_req_key_top();
-        let _ = self.history_insert_with_key_global_tagged(Box::new(cell), key, "prelude", None);
+        let cell = Box::new(cell);
+        let tag = if cell.kind() == history_cell::HistoryCellType::BackgroundEvent {
+            "background"
+        } else {
+            "prelude"
+        };
+        let _ = self.history_insert_with_key_global_tagged(cell, key, tag, None);
     }
     fn history_replace_with_record(
         &mut self,


### PR DESCRIPTION
## Summary
- Treat the recurring chromiumoxide decode error ("data did not match any variant of untagged enum Message") as transient so the browser handler no longer restarts and drops the active page after normal navigation noise.
- Add regression coverage: a unit test for the ignored error and an integration test proving BrowserManager can open a local HTTP page and keep the DOM accessible in headless and headed modes.
- Fix TUI ordering guard: background prelude inserts are now tagged as background, preventing a debug-assertion panic when starting new sessions.

## Testing
- ./build-fast.sh
- cargo test -p code-browser -- --nocapture
