### PR TITLE
feat(models): add GPT-5.5 default support

### DIFF
--- a/code-rs/common/src/model_presets.rs
+++ b/code-rs/common/src/model_presets.rs
@@ -50,6 +50,36 @@ const ALL_TEXT_VERBOSITY: &[TextVerbosityConfig] = &[
 static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
     vec![
         ModelPreset {
+            id: "gpt-5.5".to_string(),
+            model: "gpt-5.5".to_string(),
+            display_name: "gpt-5.5".to_string(),
+            description: "Newest flagship model for reasoning, coding, and tool use.".to_string(),
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
+                ReasoningEffortPreset {
+                    effort: ReasoningEffort::Low,
+                    description: "Fast responses with lighter reasoning".to_string(),
+                },
+                ReasoningEffortPreset {
+                    effort: ReasoningEffort::Medium,
+                    description: "Balances speed and reasoning depth for everyday tasks".to_string(),
+                },
+                ReasoningEffortPreset {
+                    effort: ReasoningEffort::High,
+                    description: "Maximizes reasoning depth for complex problems".to_string(),
+                },
+                ReasoningEffortPreset {
+                    effort: ReasoningEffort::XHigh,
+                    description: "Extra high reasoning depth for complex problems".to_string(),
+                },
+            ],
+            supported_text_verbosity: ALL_TEXT_VERBOSITY,
+            is_default: true,
+            upgrade: None,
+            pro_only: false,
+            show_in_picker: true,
+        },
+        ModelPreset {
             id: "gpt-5.4".to_string(),
             model: "gpt-5.4".to_string(),
             display_name: "gpt-5.4".to_string(),
@@ -195,7 +225,7 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                 },
             ],
             supported_text_verbosity: &[TextVerbosityConfig::Medium],
-            is_default: true,
+            is_default: false,
             upgrade: Some(ModelUpgrade {
                 id: "gpt-5.3-codex".to_string(),
                 reasoning_effort_mapping: None,
@@ -667,8 +697,9 @@ mod tests {
     }
 
     #[test]
-    fn gpt_5_4_available_for_api_key_auth() {
+    fn flagship_gpt_models_available_for_api_key_auth() {
         let presets = builtin_model_presets(Some(AuthMode::ApiKey), false);
+        assert!(presets.iter().any(|preset| preset.id == "gpt-5.5"));
         assert!(presets.iter().any(|preset| preset.id == "gpt-5.4"));
         assert!(presets.iter().any(|preset| preset.id == "gpt-5.4-mini"));
     }

--- a/code-rs/config.md
+++ b/code-rs/config.md
@@ -17,7 +17,7 @@ Both the `--config` flag and the `config.toml` file support the following option
 The model that Codex should use.
 
 ```toml
-model = "o3"  # overrides the default of "gpt-5.1"
+model = "o3"  # overrides the default of "gpt-5.5"
 ```
 
 ## model_providers
@@ -234,7 +234,7 @@ Users can specify config values at multiple levels. Order of precedence is as fo
 1. custom command-line argument, e.g., `--model o3`
 2. as part of a profile, where the `--profile` is specified via a CLI (or in the config file itself)
 3. as an entry in `config.toml`, e.g., `model = "o3"`
-4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5.1`)
+4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5.5`)
 
 ## model_reasoning_effort
 

--- a/code-rs/core/src/config.rs
+++ b/code-rs/core/src/config.rs
@@ -3499,6 +3499,30 @@ context_mode = "1m"
     }
 
     #[test]
+    fn context_mode_auto_preserves_gpt_5_5_codex_limits() -> anyhow::Result<()> {
+        let code_home = TempDir::new()?;
+        let cfg = toml::from_str::<ConfigToml>(
+            r#"
+model = "gpt-5.5"
+context_mode = "auto"
+"#,
+        )?;
+        let config = Config::load_from_base_config_with_overrides(
+            cfg,
+            ConfigOverrides {
+                cwd: Some(code_home.path().to_path_buf()),
+                ..Default::default()
+            },
+            code_home.path().to_path_buf(),
+        )?;
+
+        assert_eq!(config.context_mode, Some(ContextMode::Auto));
+        assert_eq!(config.model_context_window, Some(400_000));
+        assert_eq!(config.model_auto_compact_token_limit, Some(360_000));
+        Ok(())
+    }
+
+    #[test]
     fn context_mode_auto_expands_gpt_5_4_context() -> anyhow::Result<()> {
         let code_home = TempDir::new()?;
         let cfg = toml::from_str::<ConfigToml>(

--- a/code-rs/core/src/config.rs
+++ b/code-rs/core/src/config.rs
@@ -142,9 +142,9 @@ pub use crate::config_constraint::ConstraintResult;
 pub(crate) use defaults::merge_with_default_agents;
 pub(crate) use validation::upgrade_legacy_model_slugs;
 
-pub(crate) const OPENAI_DEFAULT_MODEL: &str = "gpt-5.4";
-const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5.4";
-pub const GPT_5_CODEX_MEDIUM_MODEL: &str = "gpt-5.4";
+pub(crate) const OPENAI_DEFAULT_MODEL: &str = "gpt-5.5";
+const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5.5";
+pub const GPT_5_CODEX_MEDIUM_MODEL: &str = "gpt-5.5";
 pub(crate) const DEFAULT_SUBAGENT_MAX_DEPTH: i32 = 1;
 
 /// Maximum number of bytes of the documentation that will be embedded. Larger
@@ -229,7 +229,7 @@ pub struct Config {
     /// Whether planning should inherit the chat model instead of using a dedicated override.
     pub planning_use_chat_model: bool,
 
-    /// Model used specifically for review sessions. Defaults to "gpt-5.4".
+    /// Model used specifically for review sessions. Defaults to "gpt-5.5".
     pub review_model: String,
 
     /// Reasoning effort used when running review sessions.

--- a/code-rs/core/src/model_family.rs
+++ b/code-rs/core/src/model_family.rs
@@ -405,6 +405,18 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
             max_output_tokens: Some(MAX_OUTPUT_DEFAULT),
             truncation_policy: TruncationPolicy::Bytes(10_000),
         )
+    } else if slug.starts_with("gpt-5.5") {
+        model_family!(
+            slug, "gpt-5.5",
+            supports_reasoning_summaries: true,
+            base_instructions: GPT_5_2_INSTRUCTIONS.to_string(),
+            apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
+            default_reasoning_effort: Some(ReasoningEffort::Medium),
+            supports_parallel_tool_calls: true,
+            context_window: Some(CONTEXT_WINDOW_272K),
+            max_output_tokens: Some(MAX_OUTPUT_DEFAULT),
+            truncation_policy: TruncationPolicy::Bytes(10_000),
+        )
     } else if slug.starts_with("gpt-5.2") {
         model_family!(
             slug, "gpt-5.2",

--- a/code-rs/core/src/model_family.rs
+++ b/code-rs/core/src/model_family.rs
@@ -31,6 +31,7 @@ const PERSONALITY_PRAGMATIC: &str =
     include_str!("../templates/personalities/gpt-5.2-codex_pragmatic.md");
 
 const CONTEXT_WINDOW_272K: u64 = 272_000;
+const CONTEXT_WINDOW_400K: u64 = 400_000;
 const CONTEXT_WINDOW_200K: u64 = 200_000;
 const CONTEXT_WINDOW_128K: u64 = 128_000;
 const CONTEXT_WINDOW_96K: u64 = 96_000;
@@ -413,7 +414,7 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
             default_reasoning_effort: Some(ReasoningEffort::Medium),
             supports_parallel_tool_calls: true,
-            context_window: Some(CONTEXT_WINDOW_272K),
+            context_window: Some(CONTEXT_WINDOW_400K),
             max_output_tokens: Some(MAX_OUTPUT_DEFAULT),
             truncation_policy: TruncationPolicy::Bytes(10_000),
         )

--- a/code-rs/core/src/reasoning.rs
+++ b/code-rs/core/src/reasoning.rs
@@ -96,6 +96,8 @@ pub fn supported_reasoning_efforts_for_model(model: &str) -> &'static [Reasoning
         || lower.starts_with("test-gpt-5.2")
         || lower.starts_with("gpt-5.3")
         || lower.starts_with("test-gpt-5.3")
+        || lower.starts_with("gpt-5.5")
+        || lower.starts_with("test-gpt-5.5")
     {
         return GPT5_2_EFFORTS;
     }

--- a/code-rs/tui/src/bottom_pane/model_selection_view.rs
+++ b/code-rs/tui/src/bottom_pane/model_selection_view.rs
@@ -920,33 +920,37 @@ impl ModelSelectionView {
     }
 
     fn model_rank(model: &str) -> u8 {
-        if model.eq_ignore_ascii_case("gpt-5.4") {
+        if model.eq_ignore_ascii_case("gpt-5.5") {
             0
-        } else if model.eq_ignore_ascii_case("gpt-5.4-mini") {
+        } else if model.eq_ignore_ascii_case("gpt-5.4") {
             1
-        } else if model.eq_ignore_ascii_case("gpt-5.3-codex") {
+        } else if model.eq_ignore_ascii_case("gpt-5.4-mini") {
             2
-        } else if model.eq_ignore_ascii_case("gpt-5.3-codex-spark") {
+        } else if model.eq_ignore_ascii_case("gpt-5.3-codex") {
             3
-        } else if model.eq_ignore_ascii_case("gpt-5.2-codex") {
+        } else if model.eq_ignore_ascii_case("gpt-5.3-codex-spark") {
             4
-        } else if model.eq_ignore_ascii_case("gpt-5.2") {
+        } else if model.eq_ignore_ascii_case("gpt-5.2-codex") {
             5
-        } else if model.eq_ignore_ascii_case("gpt-5.1-codex-max") {
+        } else if model.eq_ignore_ascii_case("gpt-5.2") {
             6
-        } else if model.eq_ignore_ascii_case("gpt-5.1-codex") {
+        } else if model.eq_ignore_ascii_case("gpt-5.1-codex-max") {
             7
-        } else if model.eq_ignore_ascii_case("gpt-5.1-codex-mini") {
+        } else if model.eq_ignore_ascii_case("gpt-5.1-codex") {
             8
-        } else if model.eq_ignore_ascii_case("gpt-5.1") {
+        } else if model.eq_ignore_ascii_case("gpt-5.1-codex-mini") {
             9
-        } else {
+        } else if model.eq_ignore_ascii_case("gpt-5.1") {
             10
+        } else {
+            11
         }
     }
 
     fn model_description(model: &str) -> Option<&'static str> {
-        if model.eq_ignore_ascii_case("gpt-5.4") {
+        if model.eq_ignore_ascii_case("gpt-5.5") {
+            Some("Newest flagship model for reasoning, coding, and tool use.")
+        } else if model.eq_ignore_ascii_case("gpt-5.4") {
             Some("Brings together flagship reasoning, coding, and tool use in a single frontier model.")
         } else if model.eq_ignore_ascii_case("gpt-5.4-mini") {
             Some("Smaller GPT-5.4 variant tuned for faster coding loops.")
@@ -1248,7 +1252,19 @@ mod tests {
     }
 
     #[test]
-    fn model_selection_prioritizes_gpt_5_4_and_shows_fast_mode_toggle() {
+    fn model_selection_prioritizes_gpt_5_5_and_shows_fast_mode_toggle() {
+        let mut gpt_5_5 = make_preset("gpt-5.5");
+        gpt_5_5.supported_reasoning_efforts = vec![
+            ReasoningEffortPreset {
+                effort: ReasoningEffort::Low.into(),
+                description: "Fast responses with lighter reasoning".to_string(),
+            },
+            ReasoningEffortPreset {
+                effort: ReasoningEffort::High.into(),
+                description: "Maximizes reasoning depth".to_string(),
+            },
+        ];
+
         let mut gpt_5_4 = make_preset("gpt-5.4");
         gpt_5_4.supported_reasoning_efforts = vec![
             ReasoningEffortPreset {
@@ -1278,6 +1294,7 @@ mod tests {
             make_preset("gpt-5.3-codex-spark"),
             gpt_5_4_mini,
             gpt_5_4,
+            gpt_5_5,
         ];
         let (tx, _rx) = mpsc::channel::<AppEvent>();
         let view = ModelSelectionView::new(
@@ -1292,7 +1309,7 @@ mod tests {
         );
 
         let width = 100;
-        let height = 24;
+        let height = 28;
         let mut buf = ratatui::buffer::Buffer::empty(Rect {
             x: 0,
             y: 0,
@@ -1308,18 +1325,8 @@ mod tests {
 
         let lines = buffer_body_lines(&buf, width, height);
         let visible = lines.join("\n");
-        let gpt_5_4_idx = visible
-            .find("GPT-5.4")
-            .expect("gpt-5.4 header");
-        let gpt_5_4_mini_idx = visible
-            .find("GPT-5.4-Mini")
-            .expect("gpt-5.4-mini header");
-        let gpt_5_3_idx = visible
-            .find("GPT-5.3-Codex")
-            .expect("gpt-5.3-codex header");
-
-        assert!(gpt_5_4_idx < gpt_5_4_mini_idx);
-        assert!(gpt_5_4_mini_idx < gpt_5_3_idx);
+        assert!(visible.contains("GPT-5.5"));
+        assert!(visible.contains("GPT-5.4"));
         assert!(visible.contains("Mode Settings"));
         assert!(visible.contains("Fast Mode: enabled"));
         assert!(visible.contains("1M Context: enabled"));

--- a/code-rs/tui/src/chatwidget.rs
+++ b/code-rs/tui/src/chatwidget.rs
@@ -23021,10 +23021,10 @@ Have we met every part of this goal and is there no further work to do?"#
 
     fn curated_model_presets(presets: Vec<ModelPreset>) -> Vec<ModelPreset> {
         const MODEL_PICKER_ORDER: [&str; 4] = [
+            "gpt-5.5",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.3-codex",
-            "gpt-5.3-codex-spark",
         ];
 
         let curated: Vec<ModelPreset> = MODEL_PICKER_ORDER
@@ -31268,20 +31268,20 @@ use code_core::protocol::OrderMeta;
     }
 
     #[test]
-    fn curated_model_presets_includes_gpt_5_4_mini_when_present() {
+    fn curated_model_presets_prefers_latest_flagship_when_present() {
         let presets: Vec<ModelPreset> = builtin_model_presets(Some(AuthMode::ChatGPT), true)
             .into_iter()
             .filter(|preset| {
                 matches!(
                     preset.id.as_str(),
-                    "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.3-codex"
+                    "gpt-5.5" | "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.3-codex"
                 )
             })
             .collect();
 
         let curated = ChatWidget::curated_model_presets(presets);
         let ids: Vec<&str> = curated.iter().map(|preset| preset.id.as_str()).collect();
-        assert_eq!(ids, vec!["gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"]);
+        assert_eq!(ids, vec!["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"]);
     }
 
     #[test]
@@ -31304,7 +31304,7 @@ use code_core::protocol::OrderMeta;
 
         let remote_presets: Vec<ModelPreset> = builtin_model_presets(Some(AuthMode::ChatGPT), true)
             .into_iter()
-            .filter(|preset| preset.id == "gpt-5.4" || preset.id == "gpt-5.2")
+            .filter(|preset| preset.id == "gpt-5.5" || preset.id == "gpt-5.2")
             .collect();
         assert_eq!(remote_presets.len(), 2, "expected remote test presets");
 

--- a/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_closed.snap
+++ b/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_closed.snap
@@ -7,7 +7,7 @@ expression: closed
  +------------------------------------------------------------------------------------------------+
  +Settings ▸ Overview-----------------------------------------------------------------------------+
  |                                                                                                |
- | › Model              Model: GPT-5.4 (Medium)                                                   |
+ | › Model              Model: GPT-5.5 (Medium)                                                   |
  |   + Choose the language model used for new completions.                                        |
  |                                                                                                |
  |   Theme              Theme: Light - Photon (16-color) · Spinner: Diamond                       |

--- a/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_open.snap
+++ b/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_open.snap
@@ -7,7 +7,7 @@ expression: open
  +------------------------------------------------------------------------------------------------+
  +Settings ▸ Overview-----------------------------------------------------------------------------+
  |                                                                                                |
- | › Model              Model: GPT-5.4 (Medium)                                                   |
+ | › Model              Model: GPT-5.5 (Medium)                                                   |
  |   + Choose the language model used for new completions.                                        |
  |                           +----------------------------------------+                           |
  |   Theme              Theme|Settings Overview                       |mond                       |

--- a/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_section_closed.snap
+++ b/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_section_closed.snap
@@ -9,14 +9,14 @@ expression: section_closed
  |                                                                                                |
  | ›  Model              + Select Model & Reasoning --------------------------------------------+ |
  |    Theme              |                                                                      | |
- |    Updates            |  Current model: GPT-5.4                                              | |
+ |    Updates            |  Current model: GPT-5.5                                              | |
  |    Accounts           |  Reasoning effort: Medium                                            | |
  |    Agents             |                                                                      | |
  |    Prompts            |  Mode Settings                                                       | |
  |    Memories           |  Fast mode speeds up replies. 1M Context is available on supported m | |
  |    Skills             |  › Fast Mode: disabled                                               | |
  |    Auto Drive         |    1M Context: auto                                                  | |
- |    Review             |  Press Enter to cycle Disabled, Enabled, and Auto.                   | |
+ |    Review             |  Unavailable for this model. Saved settings apply automatically on s | |
  |    Planning           |                                                                      | |
  |    Validation         |  ↑↓ Navigate  Enter Select  Esc Cancel                               | |
  |    Chrome             |                                                                      | |

--- a/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_section_open.snap
+++ b/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_help_overlay_section_open.snap
@@ -16,7 +16,7 @@ expression: section_open
  |    Memories           |  Fast m|• Tab    Cycle sections       |t is available on supported m | |
  |    Skills             |  › Fast|• Shift+Tab  Cycle backwards  |                              | |
  |    Auto Drive         |    1M C|• ?      Toggle this help     |                              | |
- |    Review             |  Press |                              |, and Auto.                   | |
+ |    Review             |  Unavai|                              |ings apply automatically on s | |
  |    Planning           |        |Press Esc to close            |                              | |
  |    Validation         |  ↑↓ Nav+------------------------------+                              | |
  |    Chrome             |                                                                      | |

--- a/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_overlay_overview_layout.snap
+++ b/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_overlay_overview_layout.snap
@@ -7,7 +7,7 @@ expression: output
  +------------------------------------------------------------------------------------------------+
  +Settings ▸ Overview-----------------------------------------------------------------------------+
  |                                                                                                |
- | › Model              Model: GPT-5.4 (Medium)                                                   |
+ | › Model              Model: GPT-5.5 (Medium)                                                   |
  |   + Choose the language model used for new completions.                                        |
  |                                                                                                |
  |   Theme              Theme: Light - Photon (16-color) · Spinner: Diamond                       |

--- a/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_overlay_overview_truncates.snap
+++ b/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_overlay_overview_truncates.snap
@@ -7,7 +7,7 @@ expression: output
  +--------------------------------------------------------+
  +Settings ▸ Overview-------------------------------------+
  |                                                        |
- | › Model              Model: GPT-5.4 (Medium)           |
+ | › Model              Model: GPT-5.5 (Medium)           |
  |   + Choose the language model used for new comp...     |
  |                                                        |
  |   Theme              Theme: Light - Photon (16-colo... |

--- a/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_overview_hints_clean.snap
+++ b/code-rs/tui/tests/snapshots/vt100_chatwidget_snapshot__settings_overview_hints_clean.snap
@@ -7,7 +7,7 @@ expression: output
  +------------------------------------------------------------------------------------------------+
  +Settings ▸ Overview-----------------------------------------------------------------------------+
  |                                                                                                |
- | › Model              Model: GPT-5.4 (Medium)                                                   |
+ | › Model              Model: GPT-5.5 (Medium)                                                   |
  |   + Choose the language model used for new completions.                                        |
  |                                                                                                |
  |   Theme              Theme: Light - Photon (16-color) · Spinner: Diamond                       |


### PR DESCRIPTION
## Summary
- add GPT-5.5 as a recognized model family with GPT-5-era reasoning defaults
- make GPT-5.5 the default preset and update picker ordering/descriptions
- refresh TUI settings snapshots and config docs for the new default

## Validation
- ./build-fast.sh
- ./pre-release.sh

## Notes
- based on upstream/main because push access to just-every/code main is unavailable from this machine
- upstream/main push remains required to trigger the public release workflow