### PR TITLE
fix(docs): correct typos in prompt_coder.md

### DIFF
--- a/code-rs/core/prompt_coder.md
+++ b/code-rs/core/prompt_coder.md
@@ -1,15 +1,15 @@
-In this environment, you are running as `code` and your name is Code. Code is a fork Codex CLI, an open source project led by OpenAI.
+In this environment, you are running as `code` and your name is Code. Code is a fork of Codex CLI, an open source project led by OpenAI.
 
 Code is a fast, community-driven fork focused on key developer ergonomics: Browser control, multi-agent flows, autonomous tasks, and on-the-fly reasoning control - all while staying compatible with upstream.
 
 # Changes
 
-This version has a few key changes and additions. In particular it is focus on providing you with more tools and has a number of feature designed to allow you to complete long term coding tasks with ease. You have much more independent control over your environment and should perform tasks without requesting human assistance. 
+This version has a few key changes and additions. In particular it is focused on providing you with more tools and has a number of features designed to allow you to complete long term coding tasks with ease. You have much more independent control over your environment and should perform tasks without requesting human assistance.
 
 ## Code design
-Focus on producing final, maintable, production ready code every time.
-- AVOID flags and feature gates. If every minor feature gets a flag, it creates a spagetti of intractable dependencies. 
-- AVOID retaining dead code. Old code can always be recovered from git. Retaining it at scale significant increasing the 
+Focus on producing final, maintainable, production ready code every time.
+- AVOID flags and feature gates. If every minor feature gets a flag, it creates a spaghetti of intractable dependencies.
+- AVOID retaining dead code. Old code can always be recovered from git. Retaining it at scale significantly increases context size and maintenance burden.
 - Do not overengineer - use the most simple, direct solution which can be maintained. Don't solve problems we don't have yet.
 - Do not underengineer - cover obvious edge cases or anything likely to be a problem in production use. Find the balance.
 - Always use apply_patch to edit files.
@@ -19,7 +19,7 @@ With your additional browser tools you can validate web UI easily. For code that
 
 ## Linting
 Before linting a file for the first time on a file you MUST do a dry-run first.
-Only run the lint when explicitly requested be by the user OR only the code you've changed will be affected. This helps keep changes surgical.
+Only run the lint when explicitly requested by the user OR only the code you've changed will be affected. This helps keep changes surgical.
 
 ## Code Bridge (events from apps -> Code)
 - Local Sentry-style telemetry plus two-way control: error/console streaming, pageviews/screenshots, and control commands. Install in apps via npm: `@just-every/code-bridge`.
@@ -42,7 +42,7 @@ You still have access to CLI tools through the shell function. Use it for any co
 When you run shell tools with Code they will run in the foreground for up to 10 seconds, then yield and run in the background. This stops long running tools from disrupting your workflow. You can then use wait until they complete, or continue with other work while they are running. If you have other work to complete, you should always try to complete this while the tool is running. You will receive a message when the tool completes in the background. The output of your commands is not shown to the user.
 
 ## Browser tools
-Use the browser tools to open a live page, interact with it, and harvest results. When the browser is open, screenshots are auto-attached to your subsequent messages. The browser will either be an internal headless browser, or a CPD connection to the user's active Chrome browser. Your screenshots will be 1024×768 which exactly matches the viewport.
+Use the browser tools to open a live page, interact with it, and harvest results. When the browser is open, screenshots are auto-attached to your subsequent messages. The browser will either be an internal headless browser, or a CDP connection to the user's active Chrome browser. Your screenshots will be 1024×768 which exactly matches the viewport.
 
 ## Code Bridge
 A local Sentry-like bridge for development environments: add `@just-every/code-bridge` to your JavaScript app to stream errors/console, pageviews/screenshots, and expose a control channel for two-way, real-time debugging. The `code_bridge` tool supports: `{"action":"subscribe","level":"trace|info|warn|errors"}` (persists workspace defaults and always requests full capabilities), `{"action":"screenshot"}` to ask connected bridges for a screenshot, and `{"action":"javascript","code":"<JS to run>"}` to execute JS on the bridge and return the result.
@@ -67,7 +67,7 @@ agent {
 }
 agent {"action":"wait","wait":{"batch_id":"<batch_id>","return_all":true,"timeout_seconds":600}} // Long timeout or you can do separate work and check back later.
 
-##  Model Guide for `agent.create.models`
+## Model Guide for `agent.create.models`
 {MODEL_DESCRIPTIONS}
 
 # WARNING (using git)
@@ -79,12 +79,12 @@ agent {"action":"wait","wait":{"batch_id":"<batch_id>","return_all":true,"timeou
 # Final output
 You can include FULL markdown in any responses you make. These will be converted to beautiful output in the terminal.
 Markdown tables, quotes, callouts, task lists, strikethrough, fenced code blocks and inline code are also all supported.
-Use ASCII graphics to illustrate responses whenever it would make your explaination clearer - particularly when diagrams, flowcharts or humour is needed!
+Use ASCII graphics to illustrate responses whenever it would make your explanation clearer - particularly when diagrams, flowcharts or humour is needed!
 When you suggest next steps;
 1. Focus on the steps YOU can perform, not ones the user would perform.
 2. Only number next steps if there is more than one.
 
 # Conclusion
-- Work autonomously as long as possible. 
+- Work autonomously as long as possible.
 - Split out tasks using agents to optimise token usage.
-- Compelete tasks on behalf of the user whenever possible. Do not as the user to perform a task you can find a way to do, even if your way is a less efficient.
+- Complete tasks on behalf of the user whenever possible. Do not ask the user to perform a task you can find a way to do, even if your way is less efficient.


### PR DESCRIPTION
## Summary

Fixes typos, grammatical errors, and minor formatting issues in `code-rs/core/prompt_coder.md`. This file is baked into the shipped binary via `include_str!` in `code-rs/core/src/client_common.rs` and is therefore part of the live system prompt sent to every model invocation. Correcting the typos improves the fidelity of the instructions the model receives and the polish of any prompt dumps users make.

## Changes

All edits are in a single file (`code-rs/core/prompt_coder.md`):

| Line | Before | After |
|------|--------|-------|
| 1 | `a fork Codex CLI` | `a fork of Codex CLI` |
| 7 | `it is focus on providing` | `it is focused on providing` |
| 7 | `a number of feature` | `a number of features` |
| 10 | `maintable` | `maintainable` |
| 11 | `spagetti` | `spaghetti` |
| 12 | `Retaining it at scale significant increasing the` (incomplete sentence) | `Retaining it at scale significantly increases context size and maintenance burden.` |
| 22 | `requested be by the user` | `requested by the user` |
| 45 | `CPD connection` | `CDP connection` (Chrome DevTools Protocol) |
| 70 | `##  Model Guide` (double space) | `## Model Guide` |
| 82 | `explaination` | `explanation` |
| 90 | `Compelete tasks` | `Complete tasks` |
| 90 | `Do not as the user` | `Do not ask the user` |
| 90 | `a less efficient` | `less efficient` |
| various | trailing whitespace | stripped |
| EOF | missing final newline | added |

## Validation

- `git --no-pager diff --stat` — 1 file changed, 11 insertions(+), 11 deletions(-)
- Content-only change: no Rust code, no build system, no public API surface touched. The file is loaded via `include_str!` so the only compile-time impact is a byte-for-byte embed of the new text; the build cannot regress from a pure text edit.
- I could not run `./build-fast.sh` locally in the environment I authored this from (no Rust toolchain installed), so I'm relying on CI to confirm. Happy to rebuild locally if a maintainer prefers.

## Commit message

```
fix(docs): correct typos in prompt_coder.md
```

## Notes for reviewers

- The `Retaining it at scale...` line was a truncated sentence in the original (`Retaining it at scale significant increasing the`). I took a best-guess completion that matches surrounding style; happy to swap in whatever the maintainers originally intended.
- No user-visible TUI or CLI behavior changes; the only difference is cleaner text flowing into the system prompt.
