### PR TITLE
tui: stop composer-anim ticker when app event channel closes

### DIFF
--- a/code-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/code-rs/tui/src/bottom_pane/chat_composer.rs
@@ -222,6 +222,20 @@ enum FilePopupOrigin {
     Manual { token: String },
 }
 
+impl Drop for ChatComposer {
+    fn drop(&mut self) {
+        // Make sure the spinner ticker thread (if any) is told to stop even
+        // if `set_task_running(false)` was never called, e.g. when this
+        // composer is torn down (view switch, session end, app exit) while
+        // a task was still marked running. Otherwise the thread keeps
+        // waking up and requesting redraws against a channel nobody reads
+        // from anymore indefinitely.
+        if let Some(animation_flag) = self.animation_running.take() {
+            animation_flag.store(false, Ordering::Relaxed);
+        }
+    }
+}
+
 impl ChatComposer {
     pub fn new(
         has_input_focus: bool,
@@ -359,7 +373,12 @@ impl ChatComposer {
                             thread::sleep(sleep_dur);
                         } else {
                             // If we're late (system busy), request a redraw immediately.
-                            app_event_tx_clone.send(crate::app_event::AppEvent::RequestRedraw);
+                            // If the app event channel is gone (receiver dropped), there is
+                            // no one left to redraw for: stop the ticker instead of spinning
+                            // forever re-sending into a closed channel.
+                            if !app_event_tx_clone.send_with_result(crate::app_event::AppEvent::RequestRedraw) {
+                                break;
+                            }
                             // Step the schedule forward by whole periods to avoid
                             // bursty catch‑up redraws.
                             let mut target = next;


### PR DESCRIPTION
## Summary

Fixes the leaked `composer-anim` ticker thread reported in #609.

- `ChatComposer::set_task_running(true)` spawns a `composer-anim` thread that periodically sends `AppEvent::RequestRedraw` to drive spinner redraws.
- That thread only stops when `set_task_running(false)` is called and only checked an `AtomicBool` flag — it never noticed if the app event channel's receiver was gone.
- If the composer was torn down (view switch, session end, app exit) while a task was still marked running, or the channel closed for any other reason, the thread looped forever: waking every ~60-120ms, calling `.send()` (result ignored), and logging `failed to send event: sending on a closed channel` indefinitely.
- Confirmed via local debug logs (`~/.code/debug_logs/critical.log.*`) that this fires in bursts (39 occurrences on one day, 81 on another) and that one such burst lined up almost exactly with a session sustaining ~100% CPU on a single core (see #609 for the correlated `ps`/`sample` data).

## Fix

- Use the existing `AppEventSender::send_with_result` (already used by the analogous `countdown` ticker in `chatwidget.rs`) and `break` the loop when it returns `false`, i.e. self-terminate once nobody is listening instead of looping forever.
- Add `impl Drop for ChatComposer` to flip the `animation_running` flag off as soon as the composer itself is dropped, so the thread doesn't need to wait for a failed send to notice it should stop.

## Testing

I don't have a working local Rust toolchain in this environment to run the full build/test suite (rustup's toolchain symlinks were broken here), so this has only been reviewed by hand against the existing `countdown` ticker pattern it mirrors. Would appreciate CI / a maintainer double-checking the build.

Closes the root cause identified in #609.