### PR TITLE
fix(core): disable storage for responses-lite requests

### DIFF
--- a/code-rs/core/src/client.rs
+++ b/code-rs/core/src/client.rs
@@ -218,7 +218,8 @@ fn should_store_responses(
     provider: &ModelProviderInfo,
     request_family: &ModelFamily,
 ) -> bool {
-    prompt.store || provider.is_azure_responses_endpoint() || request_family.use_responses_lite
+    provider.is_azure_responses_endpoint()
+        || (!request_family.use_responses_lite && prompt.store)
 }
 
 fn is_server_overloaded_error(error: &Error) -> bool {
@@ -3293,16 +3294,27 @@ mod tests {
     }
 
     #[test]
-    fn responses_storage_forces_store_for_required_providers() {
-        let prompt = Prompt::default();
+    fn responses_lite_disables_storage() {
+        let mut prompt = Prompt::default();
         let mut family = derive_default_model_family("gpt-test");
         let provider = responses_test_provider("openai", WireApi::Responses);
 
         family.use_responses_lite = true;
-        assert!(should_store_responses(&prompt, &provider, &family));
+        assert!(!should_store_responses(&prompt, &provider, &family));
 
-        family.use_responses_lite = false;
+        prompt.store = true;
+        assert!(!should_store_responses(&prompt, &provider, &family));
+    }
+
+    #[test]
+    fn responses_storage_is_forced_for_azure_provider() {
+        let prompt = Prompt::default();
+        let mut family = derive_default_model_family("gpt-test");
         let azure_provider = responses_test_provider("azure", WireApi::Responses);
+
+        assert!(should_store_responses(&prompt, &azure_provider, &family));
+
+        family.use_responses_lite = true;
         assert!(should_store_responses(&prompt, &azure_provider, &family));
     }
 


### PR DESCRIPTION
GPT-5.6 Sol and Terra use the Responses Lite API. We were sending those requests with `store: true`, but that endpoint requires `store: false`, so every request failed with a 400 and retried. This fixes that while keeping Azure’s required `store: true` behavior and the existing `Prompt.store` behavior for regular Responses requests.